### PR TITLE
Makefile error and Missing New Line on Prints

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -35,7 +35,7 @@
 all: all-libnanvix all-test
 
 # Cleans Build Objects
-clean: clean-kernel clean-libnanvix clean-test
+clean: clean-libnanvix clean-test
 
 # Cleans Everything
 distclean: distclean-libnanvix distclean-test

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -372,30 +372,30 @@ static void test_fault_mailbox_bad_wait(void)
  * @brief Unit tests.
  */
 static struct test mailbox_tests_api[] = {
-	{ test_api_mailbox_create_unlink, "[test][mailbox][api] mailbox create unlink [passed]" },
-	{ test_api_mailbox_open_close,    "[test][mailbox][api] mailbox open close    [passed]" },
-	{ test_api_mailbox_read_write,    "[test][mailbox][api] mailbox read write    [passed]" },
-	{ NULL,                            NULL                                                 },
+	{ test_api_mailbox_create_unlink, "[test][mailbox][api] mailbox create unlink [passed]\n" },
+	{ test_api_mailbox_open_close,    "[test][mailbox][api] mailbox open close    [passed]\n" },
+	{ test_api_mailbox_read_write,    "[test][mailbox][api] mailbox read write    [passed]\n" },
+	{ NULL,                            NULL                                                   },
 };
 
 /**
  * @brief Unit tests.
  */
 static struct test mailbox_tests_fault[] = {
-	{ test_fault_mailbox_invalid_create,    "[test][mailbox][fault] mailbox invalid create    [passed]" },
-	{ test_fault_mailbox_double_create,     "[test][mailbox][fault] mailbox double create     [passed]" },
-	{ test_fault_mailbox_invalid_unlink,    "[test][mailbox][fault] mailbox invalid unlink    [passed]" },
-	{ test_fault_mailbox_double_unlink,     "[test][mailbox][fault] mailbox double unlink     [passed]" },
-	{ test_fault_mailbox_invalid_open,      "[test][mailbox][fault] mailbox invalid open      [passed]" },
-	{ test_fault_mailbox_invalid_close,     "[test][mailbox][fault] mailbox invalid close     [passed]" },
-	{ test_fault_mailbox_bad_close,         "[test][mailbox][fault] mailbox bad close         [passed]" },
-	{ test_fault_mailbox_invalid_read,      "[test][mailbox][fault] mailbox invalid read      [passed]" },
-	{ test_fault_mailbox_invalid_read_size, "[test][mailbox][fault] mailbox invalid read size [passed]" },
-	{ test_fault_mailbox_null_read,         "[test][mailbox][fault] mailbox null read         [passed]" },
-	{ test_fault_mailbox_invalid_write,     "[test][mailbox][fault] mailbox invalid write     [passed]" },
-	{ test_fault_mailbox_bad_write,         "[test][mailbox][fault] mailbox bad write         [passed]" },
-	{ test_fault_mailbox_bad_wait,          "[test][mailbox][fault] mailbox bad wait          [passed]" },
-	{ NULL,                                  NULL                                                       },
+	{ test_fault_mailbox_invalid_create,    "[test][mailbox][fault] mailbox invalid create    [passed]\n" },
+	{ test_fault_mailbox_double_create,     "[test][mailbox][fault] mailbox double create     [passed]\n" },
+	{ test_fault_mailbox_invalid_unlink,    "[test][mailbox][fault] mailbox invalid unlink    [passed]\n" },
+	{ test_fault_mailbox_double_unlink,     "[test][mailbox][fault] mailbox double unlink     [passed]\n" },
+	{ test_fault_mailbox_invalid_open,      "[test][mailbox][fault] mailbox invalid open      [passed]\n" },
+	{ test_fault_mailbox_invalid_close,     "[test][mailbox][fault] mailbox invalid close     [passed]\n" },
+	{ test_fault_mailbox_bad_close,         "[test][mailbox][fault] mailbox bad close         [passed]\n" },
+	{ test_fault_mailbox_invalid_read,      "[test][mailbox][fault] mailbox invalid read      [passed]\n" },
+	{ test_fault_mailbox_invalid_read_size, "[test][mailbox][fault] mailbox invalid read size [passed]\n" },
+	{ test_fault_mailbox_null_read,         "[test][mailbox][fault] mailbox null read         [passed]\n" },
+	{ test_fault_mailbox_invalid_write,     "[test][mailbox][fault] mailbox invalid write     [passed]\n" },
+	{ test_fault_mailbox_bad_write,         "[test][mailbox][fault] mailbox bad write         [passed]\n" },
+	{ test_fault_mailbox_bad_wait,          "[test][mailbox][fault] mailbox bad wait          [passed]\n" },
+	{ NULL,                                  NULL                                                         },
 };
 
 /**
@@ -411,7 +411,7 @@ void test_mailbox(void)
 
 	/* API Tests */
 	if (nodenum == processor_node_get_num(core_get_id()))
-		nanvix_puts("--------------------------------------------------------------------------------");
+		nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (unsigned i = 0; mailbox_tests_api[i].test_fn != NULL; i++)
 	{
 		mailbox_tests_api[i].test_fn();
@@ -422,7 +422,7 @@ void test_mailbox(void)
 	if (nodenum == processor_node_get_num(core_get_id()))
 	{
 		/* Fault Tests */
-		nanvix_puts("--------------------------------------------------------------------------------");
+		nanvix_puts("--------------------------------------------------------------------------------\n");
 		for (unsigned i = 0; mailbox_tests_fault[i].test_fn != NULL; i++)
 		{
 			mailbox_tests_fault[i].test_fn();

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -372,29 +372,29 @@ static void test_fault_portal_bad_wait(void)
  * @brief Unit tests.
  */
 static struct test portal_tests_api[] = {
-	{ test_api_portal_create_unlink, "[test][portal][api] portal create unlink [passed]" },
-	{ test_api_portal_open_close,    "[test][portal][api] portal open close    [passed]" },
-	{ test_api_portal_read_write,    "[test][portal][api] portal read write    [passed]" },
-	{ NULL,                           NULL                                               },
+	{ test_api_portal_create_unlink, "[test][portal][api] portal create unlink [passed]\n" },
+	{ test_api_portal_open_close,    "[test][portal][api] portal open close    [passed]\n" },
+	{ test_api_portal_read_write,    "[test][portal][api] portal read write    [passed]\n" },
+	{ NULL,                           NULL                                                 },
 };
 
 /**
  * @brief Unit tests.
  */
 static struct test portal_tests_fault[] = {
-	{ test_fault_portal_invalid_create,    "[test][portal][fault] portal invalid create    [passed]" },
-	{ test_fault_portal_invalid_unlink,    "[test][portal][fault] portal invalid unlink    [passed]" },
-	{ test_fault_portal_double_unlink,     "[test][portal][fault] portal double unlink     [passed]" },
-	{ test_fault_portal_invalid_open,      "[test][portal][fault] portal invalid open      [passed]" },
-	{ test_fault_portal_invalid_close,     "[test][portal][fault] portal invalid close     [passed]" },
-	{ test_fault_portal_bad_close,         "[test][portal][fault] portal bad close         [passed]" },
-	{ test_fault_portal_invalid_read,      "[test][portal][fault] portal invalid read      [passed]" },
-	{ test_fault_portal_invalid_read_size, "[test][portal][fault] portal invalid read size [passed]" },
-	{ test_fault_portal_null_read,         "[test][portal][fault] portal null read         [passed]" },
-	{ test_fault_portal_invalid_write,     "[test][portal][fault] portal invalid write     [passed]" },
-	{ test_fault_portal_bad_write,         "[test][portal][fault] portal bad write         [passed]" },
-	{ test_fault_portal_bad_wait,          "[test][portal][fault] portal bad wait          [passed]" },
-	{ NULL,                                 NULL                                                     },
+	{ test_fault_portal_invalid_create,    "[test][portal][fault] portal invalid create    [passed]\n" },
+	{ test_fault_portal_invalid_unlink,    "[test][portal][fault] portal invalid unlink    [passed]\n" },
+	{ test_fault_portal_double_unlink,     "[test][portal][fault] portal double unlink     [passed]\n" },
+	{ test_fault_portal_invalid_open,      "[test][portal][fault] portal invalid open      [passed]\n" },
+	{ test_fault_portal_invalid_close,     "[test][portal][fault] portal invalid close     [passed]\n" },
+	{ test_fault_portal_bad_close,         "[test][portal][fault] portal bad close         [passed]\n" },
+	{ test_fault_portal_invalid_read,      "[test][portal][fault] portal invalid read      [passed]\n" },
+	{ test_fault_portal_invalid_read_size, "[test][portal][fault] portal invalid read size [passed]\n" },
+	{ test_fault_portal_null_read,         "[test][portal][fault] portal null read         [passed]\n" },
+	{ test_fault_portal_invalid_write,     "[test][portal][fault] portal invalid write     [passed]\n" },
+	{ test_fault_portal_bad_write,         "[test][portal][fault] portal bad write         [passed]\n" },
+	{ test_fault_portal_bad_wait,          "[test][portal][fault] portal bad wait          [passed]\n" },
+	{ NULL,                                 NULL                                                       },
 };
 
 /**
@@ -410,7 +410,7 @@ void test_portal(void)
 
 	/* API Tests */
 	if (nodenum == processor_node_get_num(core_get_id()))
-		nanvix_puts("--------------------------------------------------------------------------------");
+		nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (unsigned i = 0; portal_tests_api[i].test_fn != NULL; i++)
 	{
 		portal_tests_api[i].test_fn();
@@ -421,7 +421,7 @@ void test_portal(void)
 	/* Fault Tests */
 	if (nodenum == processor_node_get_num(core_get_id()))
 	{
-		nanvix_puts("--------------------------------------------------------------------------------");
+		nanvix_puts("--------------------------------------------------------------------------------\n");
 		for (unsigned i = 0; portal_tests_fault[i].test_fn != NULL; i++)
 		{
 			portal_tests_fault[i].test_fn();

--- a/src/test/ksync.c
+++ b/src/test/ksync.c
@@ -649,31 +649,31 @@ void test_fault_sync_bad_wait(void)
  * @brief API tests.
  */
 static struct test sync_tests_api[] = {
-	{ test_api_sync_create_unlink, "[test][sync][api] sync create/unlink [passed]" },
-	{ test_api_sync_open_close,    "[test][sync][api] sync open/close    [passed]" },
-	{ test_api_sync_signal_wait,   "[test][sync][api] sync wait          [passed]" },
-	{ NULL,                         NULL                                           },
+	{ test_api_sync_create_unlink, "[test][sync][api] sync create/unlink [passed]\n" },
+	{ test_api_sync_open_close,    "[test][sync][api] sync open/close    [passed]\n" },
+	{ test_api_sync_signal_wait,   "[test][sync][api] sync wait          [passed]\n" },
+	{ NULL,                         NULL                                             },
 };
 
 /**
  * @brief Fault tests.
  */
 static struct test sync_tests_fault[] = {
-	{ test_fault_sync_invalid_create, "[test][sync][api] sync invalid create [passed]" },
-	{ test_fault_sync_bad_create,     "[test][sync][api] sync bad create     [passed]" },
-	{ test_fault_sync_invalid_open,   "[test][sync][api] sync invalid open   [passed]" },
-	{ test_fault_sync_bad_open,       "[test][sync][api] sync bad open       [passed]" },
-	{ test_fault_sync_invalid_unlink, "[test][sync][api] sync invalid unlink [passed]" },
-	{ test_fault_sync_bad_unlink,     "[test][sync][api] sync bad unlink     [passed]" },
-	{ test_fault_sync_double_unlink,  "[test][sync][api] sync double unlink  [passed]" },
-	{ test_fault_sync_invalid_close,  "[test][sync][api] sync invalid close  [passed]" },
-	{ test_fault_sync_bad_close,      "[test][sync][api] sync bad close      [passed]" },
-	{ test_fault_sync_double_close,   "[test][sync][api] sync double close   [passed]" },
-	{ test_fault_sync_invalid_signal, "[test][sync][api] sync invalid signal [passed]" },
-	{ test_fault_sync_bad_signal,     "[test][sync][api] sync bad signal     [passed]" },
-	{ test_fault_sync_invalid_wait,   "[test][sync][api] sync invalid wait   [passed]" },
-	{ test_fault_sync_bad_wait,       "[test][sync][api] sync bad wait       [passed]" },
-	{ NULL,                            NULL                                            },
+	{ test_fault_sync_invalid_create, "[test][sync][api] sync invalid create [passed]\n" },
+	{ test_fault_sync_bad_create,     "[test][sync][api] sync bad create     [passed]\n" },
+	{ test_fault_sync_invalid_open,   "[test][sync][api] sync invalid open   [passed]\n" },
+	{ test_fault_sync_bad_open,       "[test][sync][api] sync bad open       [passed]\n" },
+	{ test_fault_sync_invalid_unlink, "[test][sync][api] sync invalid unlink [passed]\n" },
+	{ test_fault_sync_bad_unlink,     "[test][sync][api] sync bad unlink     [passed]\n" },
+	{ test_fault_sync_double_unlink,  "[test][sync][api] sync double unlink  [passed]\n" },
+	{ test_fault_sync_invalid_close,  "[test][sync][api] sync invalid close  [passed]\n" },
+	{ test_fault_sync_bad_close,      "[test][sync][api] sync bad close      [passed]\n" },
+	{ test_fault_sync_double_close,   "[test][sync][api] sync double close   [passed]\n" },
+	{ test_fault_sync_invalid_signal, "[test][sync][api] sync invalid signal [passed]\n" },
+	{ test_fault_sync_bad_signal,     "[test][sync][api] sync bad signal     [passed]\n" },
+	{ test_fault_sync_invalid_wait,   "[test][sync][api] sync invalid wait   [passed]\n" },
+	{ test_fault_sync_bad_wait,       "[test][sync][api] sync bad wait       [passed]\n" },
+	{ NULL,                            NULL                                              },
 };
 
 /**
@@ -689,7 +689,7 @@ void test_sync(void)
 
 	/* API Tests */
 	if (nodenum == processor_node_get_num(core_get_id()))
-		nanvix_puts("--------------------------------------------------------------------------------");
+		nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; sync_tests_api[i].test_fn != NULL; i++)
 	{
 		sync_tests_api[i].test_fn();
@@ -701,7 +701,7 @@ void test_sync(void)
 	if (nodenum == processor_node_get_num(core_get_id()))
 	{
 		/* Fault Tests */
-		nanvix_puts("--------------------------------------------------------------------------------");
+		nanvix_puts("--------------------------------------------------------------------------------\n");
 		for (int i = 0; sync_tests_fault[i].test_fn != NULL; i++)
 		{
 			sync_tests_fault[i].test_fn();

--- a/src/test/kthread.c
+++ b/src/test/kthread.c
@@ -216,20 +216,20 @@ static void test_stress_kthread_create(void)
  * @brief API tests.
  */
 static struct test thread_mgmt_tests_api[] = {
-	{ test_api_kthread_self,   "[test][thread][api] thread identification       [passed]" },
-	{ test_api_kthread_create, "[test][thread][api] thread creation/termination [passed]" },
-	{ NULL,                     NULL                                                      },
+	{ test_api_kthread_self,   "[test][thread][api] thread identification       [passed]\n" },
+	{ test_api_kthread_create, "[test][thread][api] thread creation/termination [passed]\n" },
+	{ NULL,                     NULL                                                        },
 };
 
 /**
  * @brief Fault tests.
  */
 static struct test thread_mgmt_tests_fault[] = {
-	{ test_fault_kthread_create_invalid,  "[test][thread][fault] invalid thread create [passed]" },
-	{ test_fault_kthread_create_bad,      "[test][thread][fault] bad thread create     [passed]" },
-	{ test_fault_kthread_join_invalid,    "[test][thread][fault] invalid thread join   [passed]" },
-	{ test_fault_kthread_join_bad,        "[test][thread][fault] bad thread join       [passed]" },
-	{ NULL,                                NULL                                                  },
+	{ test_fault_kthread_create_invalid,  "[test][thread][fault] invalid thread create [passed]\n" },
+	{ test_fault_kthread_create_bad,      "[test][thread][fault] bad thread create     [passed]\n" },
+	{ test_fault_kthread_join_invalid,    "[test][thread][fault] invalid thread join   [passed]\n" },
+	{ test_fault_kthread_join_bad,        "[test][thread][fault] bad thread join       [passed]\n" },
+	{ NULL,                                NULL                                                    },
 };
 
 /**
@@ -237,10 +237,10 @@ static struct test thread_mgmt_tests_fault[] = {
  */
 static struct test thread_mgmt_tests_stress[] = {
 #if (UTEST_KTHREAD_STRESS)
-	{ test_fault_kthread_create_overflow, "[test][thread][stress] thread creation overflow    [passed]" },
-	{ test_stress_kthread_create,         "[test][thread][stress] thread creation/termination [passed]" },
+	{ test_fault_kthread_create_overflow, "[test][thread][stress] thread creation overflow    [passed]\n" },
+	{ test_stress_kthread_create,         "[test][thread][stress] thread creation/termination [passed]\n" },
 #endif
-	{ NULL,                                NULL                                                         },
+	{ NULL,                                NULL                                                           },
 };
 
 /**
@@ -251,7 +251,7 @@ static struct test thread_mgmt_tests_stress[] = {
 void test_thread_mgmt(void)
 {
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; thread_mgmt_tests_api[i].test_fn != NULL; i++)
 	{
 		thread_mgmt_tests_api[i].test_fn();
@@ -259,7 +259,7 @@ void test_thread_mgmt(void)
 	}
 
 	/* Fault Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; thread_mgmt_tests_fault[i].test_fn != NULL; i++)
 	{
 		thread_mgmt_tests_fault[i].test_fn();
@@ -267,7 +267,7 @@ void test_thread_mgmt(void)
 	}
 
 	/* Stress Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; thread_mgmt_tests_stress[i].test_fn != NULL; i++)
 	{
 		thread_mgmt_tests_stress[i].test_fn();

--- a/src/test/perf.c
+++ b/src/test/perf.c
@@ -93,7 +93,7 @@ void test_perf(void)
 #if (CORE_HAS_PERF)
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; perf_tests_api[i].test_fn != NULL; i++)
 	{
 		perf_tests_api[i].test_fn();

--- a/src/test/signal.c
+++ b/src/test/signal.c
@@ -80,7 +80,7 @@ void test_api_signal_action(void)
  * @brief API tests.
  */
 static struct test signal_tests_api[] = {
-	{ test_api_signal_action, "[test][signal][api] signal register/unregister [passed]" },
+	{ test_api_signal_action, "[test][signal][api] signal register/unregister [passed]\n" },
 	{ NULL,                    NULL                                                       },
 };
 
@@ -121,8 +121,8 @@ void test_fault_signal_action(void)
  * @brief API tests.
  */
 static struct test signal_tests_fault[] = {
-	{ test_fault_signal_action, "[test][signal][fault] signal register/unregister [passed]" },
-	{ NULL,                      NULL                                                       },
+	{ test_fault_signal_action, "[test][signal][fault] signal register/unregister [passed]\n" },
+	{ NULL,                      NULL                                                         },
 };
 
 
@@ -138,7 +138,7 @@ void test_signal(void)
 {
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; signal_tests_api[i].test_fn != NULL; i++)
 	{
 		signal_tests_api[i].test_fn();
@@ -146,7 +146,7 @@ void test_signal(void)
 	}
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; signal_tests_fault[i].test_fn != NULL; i++)
 	{
 		signal_tests_fault[i].test_fn();

--- a/src/test/sleep.c
+++ b/src/test/sleep.c
@@ -200,16 +200,16 @@ static void test_stress_sleep_wakeup(void)
  * @brief API tests.
  */
 static struct test thread_sleep_tests_api[] = {
-	{ test_api_sleep_wakeup, "[test][thread][api] thread sleep/wakeup [passed]" },
-	{ NULL,                   NULL                                              },
+	{ test_api_sleep_wakeup, "[test][thread][api] thread sleep/wakeup [passed]\n" },
+	{ NULL,                   NULL                                                },
 };
 
 /**
  * @brief Fault injection tests.
  */
 static struct test thread_sleep_tests_fault[] = {
-	{ test_fault_sleep_wakeup, "[test][thread][fault] thread sleep/wakeup [passed]" },
-	{ NULL,                     NULL                                                },
+	{ test_fault_sleep_wakeup, "[test][thread][fault] thread sleep/wakeup [passed]\n" },
+	{ NULL,                     NULL                                                  },
 };
 
 /**
@@ -217,9 +217,9 @@ static struct test thread_sleep_tests_fault[] = {
  */
 static struct test thread_sleep_tests_stress[] = {
 #if UTEST_SLEEP_STRESS
-	{ test_stress_sleep_wakeup, "[test][thread][stress] thread sleep/wakeup [passed]" },
+	{ test_stress_sleep_wakeup, "[test][thread][stress] thread sleep/wakeup [passed]\n" },
 #endif
-	{ NULL,                      NULL                                                 },
+	{ NULL,                      NULL                                                   },
 };
 
 #endif
@@ -235,7 +235,7 @@ void test_thread_sleep(void)
 #if (THREAD_MAX > 2)
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; thread_sleep_tests_api[i].test_fn != NULL; i++)
 	{
 		thread_sleep_tests_api[i].test_fn();
@@ -243,7 +243,7 @@ void test_thread_sleep(void)
 	}
 
 	/* Fault Injection Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; thread_sleep_tests_fault[i].test_fn != NULL; i++)
 	{
 		thread_sleep_tests_fault[i].test_fn();
@@ -251,7 +251,7 @@ void test_thread_sleep(void)
 	}
 
 	/* Stress Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
+	nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; thread_sleep_tests_stress[i].test_fn != NULL; i++)
 	{
 		thread_sleep_tests_stress[i].test_fn();


### PR DESCRIPTION
In this PR, I remove `clean-kernel` label from makefile because it belongs to the microkernel level.
I also add `\n` to prints on tests.