### PR TITLE
[ikc] Kernel Call to Get/Set NoC Node Numbers

### DIFF
--- a/include/nanvix/sys/noc.h
+++ b/include/nanvix/sys/noc.h
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @addtogroup nanvix Nanvix System
+ */
+/**@{*/
+
+#ifndef NANVIX_SYS_NOC_H_
+#define NANVIX_SYS_NOC_H_
+
+	#include <nanvix/kernel/kernel.h>
+
+	/**
+	 * @name NoC Kernel Calls
+	 */
+	/**@{*/
+	extern int knode_get_num(void);
+	extern int knode_set_num(int nodenum);
+	/**@}*/
+
+#endif /* NANVIX_SYS_NOC_H_ */
+
+/**@}*/

--- a/src/libnanvix/ikc/noc.c
+++ b/src/libnanvix/ikc/noc.c
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/kernel/kernel.h>
+#include <errno.h>
+
+/*============================================================================*
+ * knode_get_num()                                                            *
+ *============================================================================*/
+
+/*
+ * @see kernel_node_get_num()
+ */
+int knode_get_num(void)
+{
+	int ret;
+    int coreid;
+
+    coreid = core_get_id();
+
+	ret = kcall1(
+		NR_node_get_num,
+		(word_t) coreid
+	);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * knode_set_num()                                                            *
+ *============================================================================*/
+
+/*
+ * @see kernel_node_set_num()
+ */
+int knode_set_num(int nodenum)
+{
+	int ret;
+    int coreid;
+
+    if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
+        return (-EINVAL);
+
+    coreid = core_get_id();
+
+	ret = kcall2(
+		NR_node_set_num,
+		(word_t) coreid,
+		(word_t) nodenum
+	);
+
+	return (ret);
+}

--- a/src/test/knoc.c
+++ b/src/test/knoc.c
@@ -1,0 +1,176 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/sys/noc.h>
+#include "test.h"
+
+/**
+ * @brief Launch verbose tests?
+ */
+#define TEST_NOC_VERBOSE 0
+
+/*============================================================================*
+ * API Tests                                                                  *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * Query Logical NoC Node Number                                              *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief API Test: Query Logical NoC Node Number
+ */
+PRIVATE void test_node_get_num(void)
+{
+	int nodenum;
+
+	nodenum = knode_get_num();
+
+#if (TEST_NOC_VERBOSE)
+	kprintf("[test][processor][node][api] noc node %d online", nodenum);
+#endif
+
+	KASSERT(nodenum == PROCESSOR_NODENUM_MASTER);
+}
+
+/*----------------------------------------------------------------------------*
+ * Exchange Logical NoC Node Number                                           *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief API Test: Exchange Logical NoC Node Number
+ */
+PRIVATE void test_node_set_num(void)
+{
+	int nodenum;
+
+	nodenum = knode_get_num();
+	KASSERT(nodenum == PROCESSOR_NODENUM_MASTER);
+
+#if (TEST_NOC_VERBOSE)
+    kprintf("[test][processor][node][api] noc node %d online", nodenum);
+#endif
+
+        /* New nodenum (1 % (Interfaces available in only one IO Cluster)) */
+        nodenum += (1 % (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM));
+
+        #if (TEST_NOC_VERBOSE)
+            kprintf("[test][processor][node][api] exchange noc node number to %d", nodenum);
+        #endif
+
+        KASSERT(knode_set_num(nodenum) == 0);
+        KASSERT(knode_get_num() == nodenum);
+
+        /* Restoure old nodenum. */
+        nodenum -= (1 % (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM));
+
+        KASSERT(knode_set_num(nodenum) == 0);
+
+	nodenum = knode_get_num();
+	KASSERT(nodenum == PROCESSOR_NODENUM_MASTER);
+}
+
+/**
+ * @brief API Tests.
+ */
+PRIVATE struct test test_api_noc[] = {
+	{ test_node_get_num,  "[test][processor][node][api] get logical noc node num [passed]\n" },
+	{ test_node_set_num,  "[test][processor][node][api] set logical noc node num [passed]\n" },
+	{ NULL,                NULL                                                              },
+};
+
+/*============================================================================*
+ * FAULT Tests                                                                *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * Exchange Logical NoC Node Number with invalid arguments                    *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief FAULT Test: Invalid Set Logical NoC Node Number
+ */
+PRIVATE void test_node_invalid_set_num(void)
+{
+	/* Invalid nodenum. */
+	KASSERT(knode_set_num(-1) == -EINVAL);
+	KASSERT(knode_set_num(PROCESSOR_NOC_NODES_NUM) == -EINVAL);
+}
+
+/*----------------------------------------------------------------------------*
+ * Exchange Logical NoC Node Number with bad arguments                        *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief FAULT Test: Bad Set Logical NoC Node Number
+ */
+PRIVATE void test_node_bad_set_num(void)
+{
+	int nodenum;
+
+	/* nodenum + (Interfaces available in only one IO Cluster). */
+	nodenum = PROCESSOR_NODENUM_MASTER + (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM);
+
+	/* Bad nodenum. */
+	KASSERT(knode_set_num(nodenum) == -EINVAL);
+}
+
+/*============================================================================*
+ * Test Driver                                                                *
+ *============================================================================*/
+
+/**
+ * @brief API Tests.
+ */
+PRIVATE struct test test_fault_noc[] = {
+	{ test_node_invalid_set_num, "[test][processor][node][fault] invalid set logical noc node num [passed]\n" },
+	{ test_node_bad_set_num,     "[test][processor][node][fault] bad set logical noc node num     [passed]\n" },
+	{ NULL,                       NULL                                                                        },
+};
+
+/**
+ * The test_noc() function launches regression tests on the NoC
+ * Interface of the Processor Abstraction Layer.
+ *
+ * @author Pedro Henrique Penna
+ * @author João Vicente Souto
+ */
+PUBLIC void test_noc(void)
+{
+	/* API Tests */
+	nanvix_puts("--------------------------------------------------------------------------------\n");
+	for (int i = 0; test_api_noc[i].test_fn != NULL; i++)
+	{
+		test_api_noc[i].test_fn();
+        nanvix_puts(test_api_noc[i].name);
+	}
+
+	/* FAULT Tests */
+	nanvix_puts("--------------------------------------------------------------------------------\n");
+	for (int i = 0; test_fault_noc[i].test_fn != NULL; i++)
+	{
+		test_fault_noc[i].test_fn();
+        nanvix_puts(test_fault_noc[i].name);
+	}
+}

--- a/src/test/ksync.c
+++ b/src/test/ksync.c
@@ -24,6 +24,7 @@
  */
 
 #include <nanvix/sys/sync.h>
+#include <nanvix/sys/noc.h>
 #include <posix/errno.h>
 
 #include "test.h"
@@ -58,7 +59,7 @@ void test_api_sync_create_unlink(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodes[0] = processor_node_get_num(core_get_id());
+	nodes[0] = knode_get_num();
 
 	for (int i = 0, j = 1; i < NR_NODES; i++)
 	{
@@ -84,7 +85,7 @@ void test_api_sync_open_close(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodes[0] = processor_node_get_num(core_get_id());
+	nodes[0] = knode_get_num();
 
 	for (int i = 0, j = 1; i < NR_NODES; i++)
 	{
@@ -112,7 +113,7 @@ void test_api_sync_signal_wait(void)
 	int nodenum;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = MASTER_NODENUM;
 
 	for (int i = 0, j = 1; i < NR_NODES; i++)
@@ -162,7 +163,7 @@ void test_fault_sync_invalid_create(void)
 	int nodenum;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = (nodenum == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
 	for (int i = 0, j = 1; i < NR_NODES; i++)
@@ -197,7 +198,7 @@ void test_fault_sync_bad_create1(void)
 	int nodenum;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 
 	/* Invalid list of NoC nodes. */
 	for (int i = NR_NODES - 1; i >= 0; i--)
@@ -241,7 +242,7 @@ void test_fault_sync_bad_create2(void)
 	int nodenum;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 
 	/* Invalid list of NoC nodes. */
 	for (int i = NR_NODES - 1; i >= 0; i--)
@@ -297,7 +298,7 @@ void test_fault_sync_invalid_open(void)
 	int nodenum;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Build nodes list. */
@@ -333,7 +334,7 @@ void test_fault_sync_bad_open1(void)
 	int nodenum;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Invalid list of NoC nodes. */
@@ -369,7 +370,7 @@ void test_fault_sync_bad_open2(void)
 	int nodenum;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 
 	/* Invalid list of NoC nodes. */
 	for (int i = NR_NODES - 1; i >= 0; i--)
@@ -432,7 +433,7 @@ void test_fault_sync_bad_unlink(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Build nodes list. */
@@ -462,7 +463,7 @@ void test_fault_sync_double_unlink(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Build nodes list. */
@@ -506,7 +507,7 @@ void test_fault_sync_bad_close(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Build nodes list. */
@@ -536,7 +537,7 @@ void test_fault_sync_double_close(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Build nodes list. */
@@ -580,7 +581,7 @@ void test_fault_sync_bad_signal(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Build nodes list. */
@@ -624,7 +625,7 @@ void test_fault_sync_bad_wait(void)
 	int syncid;
 	int nodes[NR_NODES];
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 	nodes[0] = nodenum;
 
 	/* Build nodes list. */
@@ -685,20 +686,20 @@ void test_sync(void)
 {
 	int nodenum;
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = knode_get_num();
 
 	/* API Tests */
-	if (nodenum == processor_node_get_num(core_get_id()))
+	if (nodenum == PROCESSOR_NODENUM_MASTER)
 		nanvix_puts("--------------------------------------------------------------------------------\n");
 	for (int i = 0; sync_tests_api[i].test_fn != NULL; i++)
 	{
 		sync_tests_api[i].test_fn();
 
-		if (nodenum == processor_node_get_num(core_get_id()))
+		if (nodenum == PROCESSOR_NODENUM_MASTER)
 			nanvix_puts(sync_tests_api[i].name);
 	}
 
-	if (nodenum == processor_node_get_num(core_get_id()))
+	if (nodenum == PROCESSOR_NODENUM_MASTER)
 	{
 		/* Fault Tests */
 		nanvix_puts("--------------------------------------------------------------------------------\n");

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -98,7 +98,7 @@ void ___start(int argc, const char *argv[])
 
 	nodenum = processor_node_get_num(core_get_id());
 
-	if (nodenum == processor_node_get_num(core_get_id()))
+	if (nodenum == PROCESSOR_NODENUM_MASTER)
 	{
 		test_thread_mgmt();
 		test_thread_sleep();
@@ -107,6 +107,8 @@ void ___start(int argc, const char *argv[])
 		test_perf();
 		test_signal();
 #endif
+
+		test_noc();
 	}
 
 	#if __TARGET_HAS_SYNC

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -65,6 +65,7 @@
 	extern void test_perf(void);
 	extern void test_signal(void);
 	extern void test_network(void);
+	extern void test_noc(void);
 	extern void test_sync(void);
 	extern void test_mailbox(void);
 	extern void test_portal(void);


### PR DESCRIPTION
In this PR, I add kernel calls to get/set node numbers and the related tests.
I also update the old calls in other parts of the code.

Related Issues
--------------------

- [[test] Unit Tests for NoC Kernel Calls](https://github.com/nanvix/libnanvix/issues/2)
