### PR TITLE
[test] Unit tests for Sync Multiplex

### DIFF
--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -666,38 +666,38 @@ static void test_fault_mailbox_bad_ioctl(void)
  * @brief Unit tests.
  */
 static struct test mailbox_tests_api[] = {
-	{ test_api_mailbox_create_unlink,        "[test][mailbox][api] mailbox create unlink        [passed]\n" },
-	{ test_api_mailbox_open_close,           "[test][mailbox][api] mailbox open close           [passed]\n" },
-	{ test_api_mailbox_get_volume,           "[test][mailbox][api] mailbox get volume           [passed]\n" },
-	{ test_api_mailbox_get_latency,          "[test][mailbox][api] mailbox get latency          [passed]\n" },
-	{ test_api_mailbox_read_write,           "[test][mailbox][api] mailbox read write           [passed]\n" },
-	{ test_api_mailbox_multiple_create_open, "[test][mailbox][api] mailbox multiple create open [passed]\n" },
-	{ test_api_mailbox_multiplex,            "[test][mailbox][api] mailbox multiplex            [passed]\n" },
-	{ NULL,                                   NULL                                                          },
+	{ test_api_mailbox_create_unlink,        "[test][mailbox][api] mailbox create unlink        [passed]" },
+	{ test_api_mailbox_open_close,           "[test][mailbox][api] mailbox open close           [passed]" },
+	{ test_api_mailbox_get_volume,           "[test][mailbox][api] mailbox get volume           [passed]" },
+	{ test_api_mailbox_get_latency,          "[test][mailbox][api] mailbox get latency          [passed]" },
+	{ test_api_mailbox_read_write,           "[test][mailbox][api] mailbox read write           [passed]" },
+	{ test_api_mailbox_multiple_create_open, "[test][mailbox][api] mailbox multiple create open [passed]" },
+	{ test_api_mailbox_multiplex,            "[test][mailbox][api] mailbox multiplex            [passed]" },
+	{ NULL,                                   NULL                                                        },
 };
 
 /**
  * @brief Unit tests.
  */
 static struct test mailbox_tests_fault[] = {
-	{ test_fault_mailbox_invalid_create,    "[test][mailbox][fault] mailbox invalid create    [passed]\n" },
-	{ test_fault_mailbox_bad_create,        "[test][mailbox][fault] mailbox bad create        [passed]\n" },
-	{ test_fault_mailbox_invalid_unlink,    "[test][mailbox][fault] mailbox invalid unlink    [passed]\n" },
-	{ test_fault_mailbox_double_unlink,     "[test][mailbox][fault] mailbox double unlink     [passed]\n" },
-	{ test_fault_mailbox_invalid_open,      "[test][mailbox][fault] mailbox invalid open      [passed]\n" },
-	{ test_fault_mailbox_bad_open,          "[test][mailbox][fault] mailbox bad open          [passed]\n" },
-	{ test_fault_mailbox_invalid_close,     "[test][mailbox][fault] mailbox invalid close     [passed]\n" },
-	{ test_fault_mailbox_double_close,      "[test][mailbox][fault] mailbox double close      [passed]\n" },
-	{ test_fault_mailbox_bad_close,         "[test][mailbox][fault] mailbox bad close         [passed]\n" },
-	{ test_fault_mailbox_invalid_read,      "[test][mailbox][fault] mailbox invalid read      [passed]\n" },
-	{ test_fault_mailbox_invalid_read_size, "[test][mailbox][fault] mailbox invalid read size [passed]\n" },
-	{ test_fault_mailbox_null_read,         "[test][mailbox][fault] mailbox null read         [passed]\n" },
-	{ test_fault_mailbox_invalid_write,     "[test][mailbox][fault] mailbox invalid write     [passed]\n" },
-	{ test_fault_mailbox_bad_write,         "[test][mailbox][fault] mailbox bad write         [passed]\n" },
-	{ test_fault_mailbox_bad_wait,          "[test][mailbox][fault] mailbox bad wait          [passed]\n" },
-	{ test_fault_mailbox_invalid_ioctl,     "[test][mailbox][fault] mailbox invalid ioctl     [passed]\n" },
-	{ test_fault_mailbox_bad_ioctl,         "[test][mailbox][fault] mailbox bad ioctl         [passed]\n" },
-	{ NULL,                                  NULL                                                         },
+	{ test_fault_mailbox_invalid_create,    "[test][mailbox][fault] mailbox invalid create    [passed]" },
+	{ test_fault_mailbox_bad_create,        "[test][mailbox][fault] mailbox bad create        [passed]" },
+	{ test_fault_mailbox_invalid_unlink,    "[test][mailbox][fault] mailbox invalid unlink    [passed]" },
+	{ test_fault_mailbox_double_unlink,     "[test][mailbox][fault] mailbox double unlink     [passed]" },
+	{ test_fault_mailbox_invalid_open,      "[test][mailbox][fault] mailbox invalid open      [passed]" },
+	{ test_fault_mailbox_bad_open,          "[test][mailbox][fault] mailbox bad open          [passed]" },
+	{ test_fault_mailbox_invalid_close,     "[test][mailbox][fault] mailbox invalid close     [passed]" },
+	{ test_fault_mailbox_double_close,      "[test][mailbox][fault] mailbox double close      [passed]" },
+	{ test_fault_mailbox_bad_close,         "[test][mailbox][fault] mailbox bad close         [passed]" },
+	{ test_fault_mailbox_invalid_read,      "[test][mailbox][fault] mailbox invalid read      [passed]" },
+	{ test_fault_mailbox_invalid_read_size, "[test][mailbox][fault] mailbox invalid read size [passed]" },
+	{ test_fault_mailbox_null_read,         "[test][mailbox][fault] mailbox null read         [passed]" },
+	{ test_fault_mailbox_invalid_write,     "[test][mailbox][fault] mailbox invalid write     [passed]" },
+	{ test_fault_mailbox_bad_write,         "[test][mailbox][fault] mailbox bad write         [passed]" },
+	{ test_fault_mailbox_bad_wait,          "[test][mailbox][fault] mailbox bad wait          [passed]" },
+	{ test_fault_mailbox_invalid_ioctl,     "[test][mailbox][fault] mailbox invalid ioctl     [passed]" },
+	{ test_fault_mailbox_bad_ioctl,         "[test][mailbox][fault] mailbox bad ioctl         [passed]" },
+	{ NULL,                                  NULL                                                       },
 };
 
 /**
@@ -715,7 +715,7 @@ void test_mailbox(void)
 	{
 		/* API Tests */
 		if (nodenum == MASTER_NODENUM)
-			nanvix_puts("--------------------------------------------------------------------------------\n");
+			nanvix_puts("--------------------------------------------------------------------------------");
 		for (unsigned i = 0; mailbox_tests_api[i].test_fn != NULL; i++)
 		{
 			mailbox_tests_api[i].test_fn();
@@ -726,7 +726,7 @@ void test_mailbox(void)
 
 		/* Fault Tests */
 		if (nodenum == MASTER_NODENUM)
-			nanvix_puts("--------------------------------------------------------------------------------\n");
+			nanvix_puts("--------------------------------------------------------------------------------");
 		for (unsigned i = 0; mailbox_tests_fault[i].test_fn != NULL; i++)
 		{
 			mailbox_tests_fault[i].test_fn();

--- a/src/test/knoc.c
+++ b/src/test/knoc.c
@@ -135,18 +135,18 @@ PRIVATE void test_node_bad_set_num(void)
  * @brief API Tests.
  */
 PRIVATE struct test test_api_noc[] = {
-	{ test_node_get_num,  "[test][processor][node][api] get logical noc node num [passed]\n" },
-	{ test_node_set_num,  "[test][processor][node][api] set logical noc node num [passed]\n" },
-	{ NULL,                NULL                                                              },
+	{ test_node_get_num,  "[test][processor][node][api] get logical noc node num [passed]" },
+	{ test_node_set_num,  "[test][processor][node][api] set logical noc node num [passed]" },
+	{ NULL,                NULL                                                            },
 };
 
 /**
  * @brief FAULT Tests.
  */
 PRIVATE struct test test_fault_noc[] = {
-	{ test_node_invalid_set_num, "[test][processor][node][fault] invalid set logical noc node num [passed]\n" },
-	{ test_node_bad_set_num,     "[test][processor][node][fault] bad set logical noc node num     [passed]\n" },
-	{ NULL,                       NULL                                                                        },
+	{ test_node_invalid_set_num, "[test][processor][node][fault] invalid set logical noc node num [passed]" },
+	{ test_node_bad_set_num,     "[test][processor][node][fault] bad set logical noc node num     [passed]" },
+	{ NULL,                       NULL                                                                      },
 };
 
 /**
@@ -159,7 +159,7 @@ PRIVATE struct test test_fault_noc[] = {
 PUBLIC void test_noc(void)
 {
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; test_api_noc[i].test_fn != NULL; i++)
 	{
 		test_api_noc[i].test_fn();
@@ -167,7 +167,7 @@ PUBLIC void test_noc(void)
 	}
 
 	/* FAULT Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; test_fault_noc[i].test_fn != NULL; i++)
 	{
 		test_fault_noc[i].test_fn();

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -755,39 +755,39 @@ static void test_fault_portal_bad_ioctl(void)
  * @brief Unit tests.
  */
 static struct test portal_tests_api[] = {
-	{ test_api_portal_create_unlink,        "[test][portal][api] portal create unlink        [passed]\n" },
-	{ test_api_portal_open_close,           "[test][portal][api] portal open close           [passed]\n" },
-	{ test_api_portal_get_volume,           "[test][portal][api] portal get volume           [passed]\n" },
-	{ test_api_portal_get_latency,          "[test][portal][api] portal get latency          [passed]\n" },
-	{ test_api_portal_read_write,           "[test][portal][api] portal read write           [passed]\n" },
-	{ test_api_portal_multiple_create_open, "[test][portal][api] portal multiple create open [passed]\n" },
-	{ test_api_portal_multiplex,            "[test][portal][api] portal multiplex            [passed]\n" },
-	{ test_api_portal_allow,                "[test][portal][api] portal allow                [passed]\n" },
-	{ NULL,                                  NULL                                                        },
+	{ test_api_portal_create_unlink,        "[test][portal][api] portal create unlink        [passed]" },
+	{ test_api_portal_open_close,           "[test][portal][api] portal open close           [passed]" },
+	{ test_api_portal_get_volume,           "[test][portal][api] portal get volume           [passed]" },
+	{ test_api_portal_get_latency,          "[test][portal][api] portal get latency          [passed]" },
+	{ test_api_portal_read_write,           "[test][portal][api] portal read write           [passed]" },
+	{ test_api_portal_multiple_create_open, "[test][portal][api] portal multiple create open [passed]" },
+	{ test_api_portal_multiplex,            "[test][portal][api] portal multiplex            [passed]" },
+	{ test_api_portal_allow,                "[test][portal][api] portal allow                [passed]" },
+	{ NULL,                                  NULL                                                      },
 };
 
 /**
  * @brief Unit tests.
  */
 static struct test portal_tests_fault[] = {
-	{ test_fault_portal_invalid_create,    "[test][portal][fault] portal invalid create    [passed]\n" },
-	{ test_fault_portal_invalid_unlink,    "[test][portal][fault] portal invalid unlink    [passed]\n" },
-	{ test_fault_portal_bad_unlink,        "[test][portal][fault] portal bad unlink        [passed]\n" },
-	{ test_fault_portal_double_unlink,     "[test][portal][fault] portal double unlink     [passed]\n" },
-	{ test_fault_portal_invalid_open,      "[test][portal][fault] portal invalid open      [passed]\n" },
-	{ test_fault_portal_invalid_close,     "[test][portal][fault] portal invalid close     [passed]\n" },
-	{ test_fault_portal_bad_close,         "[test][portal][fault] portal bad close         [passed]\n" },
-	{ test_fault_portal_double_close,      "[test][portal][fault] portal double close      [passed]\n" },
-	{ test_fault_portal_bad_allow,         "[test][portal][fault] portal bad allow         [passed]\n" },
-	{ test_fault_portal_invalid_read,      "[test][portal][fault] portal invalid read      [passed]\n" },
-	{ test_fault_portal_invalid_read_size, "[test][portal][fault] portal invalid read size [passed]\n" },
-	{ test_fault_portal_null_read,         "[test][portal][fault] portal null read         [passed]\n" },
-	{ test_fault_portal_invalid_write,     "[test][portal][fault] portal invalid write     [passed]\n" },
-	{ test_fault_portal_bad_write,         "[test][portal][fault] portal bad write         [passed]\n" },
-	{ test_fault_portal_bad_wait,          "[test][portal][fault] portal bad wait          [passed]\n" },
-	{ test_fault_portal_invalid_ioctl,     "[test][portal][fault] portal invalid ioctl     [passed]\n" },
-	{ test_fault_portal_bad_ioctl,         "[test][portal][fault] portal bad ioctl         [passed]\n" },
-	{ NULL,                                 NULL                                                       },
+	{ test_fault_portal_invalid_create,    "[test][portal][fault] portal invalid create    [passed]" },
+	{ test_fault_portal_invalid_unlink,    "[test][portal][fault] portal invalid unlink    [passed]" },
+	{ test_fault_portal_bad_unlink,        "[test][portal][fault] portal bad unlink        [passed]" },
+	{ test_fault_portal_double_unlink,     "[test][portal][fault] portal double unlink     [passed]" },
+	{ test_fault_portal_invalid_open,      "[test][portal][fault] portal invalid open      [passed]" },
+	{ test_fault_portal_invalid_close,     "[test][portal][fault] portal invalid close     [passed]" },
+	{ test_fault_portal_bad_close,         "[test][portal][fault] portal bad close         [passed]" },
+	{ test_fault_portal_double_close,      "[test][portal][fault] portal double close      [passed]" },
+	{ test_fault_portal_bad_allow,         "[test][portal][fault] portal bad allow         [passed]" },
+	{ test_fault_portal_invalid_read,      "[test][portal][fault] portal invalid read      [passed]" },
+	{ test_fault_portal_invalid_read_size, "[test][portal][fault] portal invalid read size [passed]" },
+	{ test_fault_portal_null_read,         "[test][portal][fault] portal null read         [passed]" },
+	{ test_fault_portal_invalid_write,     "[test][portal][fault] portal invalid write     [passed]" },
+	{ test_fault_portal_bad_write,         "[test][portal][fault] portal bad write         [passed]" },
+	{ test_fault_portal_bad_wait,          "[test][portal][fault] portal bad wait          [passed]" },
+	{ test_fault_portal_invalid_ioctl,     "[test][portal][fault] portal invalid ioctl     [passed]" },
+	{ test_fault_portal_bad_ioctl,         "[test][portal][fault] portal bad ioctl         [passed]" },
+	{ NULL,                                 NULL                                                     },
 };
 
 /**
@@ -805,7 +805,7 @@ void test_portal(void)
 	{
 		/* API Tests */
 		if (nodenum == MASTER_NODENUM)
-			nanvix_puts("--------------------------------------------------------------------------------\n");
+			nanvix_puts("--------------------------------------------------------------------------------");
 		for (unsigned i = 0; portal_tests_api[i].test_fn != NULL; i++)
 		{
 			portal_tests_api[i].test_fn();
@@ -816,7 +816,7 @@ void test_portal(void)
 
 		/* Fault Tests */
 		if (nodenum == MASTER_NODENUM)
-			nanvix_puts("--------------------------------------------------------------------------------\n");
+			nanvix_puts("--------------------------------------------------------------------------------");
 		for (unsigned i = 0; portal_tests_fault[i].test_fn != NULL; i++)
 		{
 			portal_tests_fault[i].test_fn();

--- a/src/test/ksync.c
+++ b/src/test/ksync.c
@@ -44,6 +44,12 @@
 #endif
 
 /**
+ * @brief Multiple open / create test parameters.
+ */
+#define TEST_NR_INPUT_SYNCS  3
+#define TEST_NR_OUTPUT_SYNCS 7
+
+/**
  * @brief Auxiliar array
  */
 int nodenums[NR_NODES] = {
@@ -117,6 +123,66 @@ void test_api_sync_open_close(void)
 
 	test_assert((syncid = ksync_open(nodes, NR_NODES, SYNC_ALL_TO_ONE)) >= 0);
 	test_assert(ksync_close(syncid) == 0);
+}
+
+/*============================================================================*
+ * API Test: Multiple Create Open                                                       *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Synchronization Point Multiple Create Open
+ */
+void test_api_sync_multiple_create_open(void)
+{
+	int tmp;
+	int sync_in[TEST_NR_INPUT_SYNCS];
+	int sync_out[TEST_NR_OUTPUT_SYNCS];
+	int nodes[NR_NODES];
+
+	nodes[0] = knode_get_num();
+
+	for (int i = 0, j = 1; i < NR_NODES; i++)
+	{
+		if (nodenums[i] == nodes[0])
+			continue;
+
+		nodes[j++] = nodenums[i];
+	}
+
+	/* Creates multiple virtual synchronization points. */
+	for (unsigned i = 0; i < TEST_NR_INPUT_SYNCS; ++i)
+		test_assert((sync_in[i] = ksync_create(nodes, NR_NODES, SYNC_ALL_TO_ONE)) >= 0);
+
+	for (unsigned i = 0; i < TEST_NR_INPUT_SYNCS; ++i)
+		test_assert(ksync_unlink(sync_in[i]) == 0);
+
+	tmp = nodes[0];
+	nodes[0] = nodes[1];
+	nodes[1] = tmp;
+
+	for (unsigned i = 0; i < TEST_NR_INPUT_SYNCS; ++i)
+		test_assert((sync_in[i] = ksync_create(nodes, NR_NODES, SYNC_ONE_TO_ALL)) >= 0);
+
+	/* Opens multiple virtual synchronization points. */
+	for (unsigned i = 0; i < TEST_NR_OUTPUT_SYNCS; ++i)
+		test_assert((sync_out[i] = ksync_open(nodes, NR_NODES, SYNC_ALL_TO_ONE)) >= 0);
+
+	for (unsigned i = 0; i < TEST_NR_OUTPUT_SYNCS; ++i)
+		test_assert(ksync_close(sync_out[i]) == 0);
+
+	tmp = nodes[0];
+	nodes[0] = nodes[1];
+	nodes[1] = tmp;
+
+	for (unsigned i = 0; i < TEST_NR_OUTPUT_SYNCS; ++i)
+		test_assert((sync_out[i] = ksync_open(nodes, NR_NODES, SYNC_ONE_TO_ALL)) >= 0);
+
+	/* Deletion of the created virtual synchronization points. */
+	for (unsigned i = 0; i < TEST_NR_INPUT_SYNCS; ++i)
+		test_assert(ksync_unlink(sync_in[i]) == 0);
+
+	for (unsigned i = 0; i < TEST_NR_OUTPUT_SYNCS; ++i)
+		test_assert(ksync_close(sync_out[i]) == 0);
 }
 
 /*============================================================================*
@@ -678,10 +744,11 @@ void test_fault_sync_bad_wait(void)
  * @brief API tests.
  */
 static struct test sync_tests_api[] = {
-	{ test_api_sync_create_unlink, "[test][sync][api] sync create/unlink [passed]\n" },
-	{ test_api_sync_open_close,    "[test][sync][api] sync open/close    [passed]\n" },
-	{ test_api_sync_signal_wait,   "[test][sync][api] sync wait          [passed]\n" },
-	{ NULL,                         NULL                                             },
+	{ test_api_sync_create_unlink,        "[test][sync][api] sync create/unlink        [passed]\n" },
+	{ test_api_sync_open_close,           "[test][sync][api] sync open/close           [passed]\n" },
+	{ test_api_sync_multiple_create_open, "[test][sync][api] sync multiple create open [passed]\n" },
+	{ test_api_sync_signal_wait,          "[test][sync][api] sync wait                 [passed]\n" },
+	{ NULL,                                NULL                                                    },
 };
 
 /**

--- a/src/test/ksync.c
+++ b/src/test/ksync.c
@@ -744,32 +744,32 @@ void test_fault_sync_bad_wait(void)
  * @brief API tests.
  */
 static struct test sync_tests_api[] = {
-	{ test_api_sync_create_unlink,        "[test][sync][api] sync create/unlink        [passed]\n" },
-	{ test_api_sync_open_close,           "[test][sync][api] sync open/close           [passed]\n" },
-	{ test_api_sync_multiple_create_open, "[test][sync][api] sync multiple create open [passed]\n" },
-	{ test_api_sync_signal_wait,          "[test][sync][api] sync wait                 [passed]\n" },
-	{ NULL,                                NULL                                                    },
+	{ test_api_sync_create_unlink,        "[test][sync][api] sync create/unlink        [passed]" },
+	{ test_api_sync_open_close,           "[test][sync][api] sync open/close           [passed]" },
+	{ test_api_sync_multiple_create_open, "[test][sync][api] sync multiple create open [passed]" },
+	{ test_api_sync_signal_wait,          "[test][sync][api] sync wait                 [passed]" },
+	{ NULL,                                NULL                                                  },
 };
 
 /**
  * @brief Fault tests.
  */
 static struct test sync_tests_fault[] = {
-	{ test_fault_sync_invalid_create, "[test][sync][api] sync invalid create [passed]\n" },
-	{ test_fault_sync_bad_create,     "[test][sync][api] sync bad create     [passed]\n" },
-	{ test_fault_sync_invalid_open,   "[test][sync][api] sync invalid open   [passed]\n" },
-	{ test_fault_sync_bad_open,       "[test][sync][api] sync bad open       [passed]\n" },
-	{ test_fault_sync_invalid_unlink, "[test][sync][api] sync invalid unlink [passed]\n" },
-	{ test_fault_sync_bad_unlink,     "[test][sync][api] sync bad unlink     [passed]\n" },
-	{ test_fault_sync_double_unlink,  "[test][sync][api] sync double unlink  [passed]\n" },
-	{ test_fault_sync_invalid_close,  "[test][sync][api] sync invalid close  [passed]\n" },
-	{ test_fault_sync_bad_close,      "[test][sync][api] sync bad close      [passed]\n" },
-	{ test_fault_sync_double_close,   "[test][sync][api] sync double close   [passed]\n" },
-	{ test_fault_sync_invalid_signal, "[test][sync][api] sync invalid signal [passed]\n" },
-	{ test_fault_sync_bad_signal,     "[test][sync][api] sync bad signal     [passed]\n" },
-	{ test_fault_sync_invalid_wait,   "[test][sync][api] sync invalid wait   [passed]\n" },
-	{ test_fault_sync_bad_wait,       "[test][sync][api] sync bad wait       [passed]\n" },
-	{ NULL,                            NULL                                              },
+	{ test_fault_sync_invalid_create, "[test][sync][api] sync invalid create [passed]" },
+	{ test_fault_sync_bad_create,     "[test][sync][api] sync bad create     [passed]" },
+	{ test_fault_sync_invalid_open,   "[test][sync][api] sync invalid open   [passed]" },
+	{ test_fault_sync_bad_open,       "[test][sync][api] sync bad open       [passed]" },
+	{ test_fault_sync_invalid_unlink, "[test][sync][api] sync invalid unlink [passed]" },
+	{ test_fault_sync_bad_unlink,     "[test][sync][api] sync bad unlink     [passed]" },
+	{ test_fault_sync_double_unlink,  "[test][sync][api] sync double unlink  [passed]" },
+	{ test_fault_sync_invalid_close,  "[test][sync][api] sync invalid close  [passed]" },
+	{ test_fault_sync_bad_close,      "[test][sync][api] sync bad close      [passed]" },
+	{ test_fault_sync_double_close,   "[test][sync][api] sync double close   [passed]" },
+	{ test_fault_sync_invalid_signal, "[test][sync][api] sync invalid signal [passed]" },
+	{ test_fault_sync_bad_signal,     "[test][sync][api] sync bad signal     [passed]" },
+	{ test_fault_sync_invalid_wait,   "[test][sync][api] sync invalid wait   [passed]" },
+	{ test_fault_sync_bad_wait,       "[test][sync][api] sync bad wait       [passed]" },
+	{ NULL,                            NULL                                            },
 };
 
 /**
@@ -787,7 +787,7 @@ void test_sync(void)
 	{
 		/* API Tests */
 		if (nodenum == MASTER_NODENUM)
-			nanvix_puts("--------------------------------------------------------------------------------\n");
+			nanvix_puts("--------------------------------------------------------------------------------");
 		for (int i = 0; sync_tests_api[i].test_fn != NULL; i++)
 		{
 			sync_tests_api[i].test_fn();
@@ -798,7 +798,7 @@ void test_sync(void)
 
 		/* Fault Tests */
 		if (nodenum == MASTER_NODENUM)
-			nanvix_puts("--------------------------------------------------------------------------------\n");
+			nanvix_puts("--------------------------------------------------------------------------------");
 		for (int i = 0; sync_tests_fault[i].test_fn != NULL; i++)
 		{
 			sync_tests_fault[i].test_fn();

--- a/src/test/kthread.c
+++ b/src/test/kthread.c
@@ -216,20 +216,20 @@ static void test_stress_kthread_create(void)
  * @brief API tests.
  */
 static struct test thread_mgmt_tests_api[] = {
-	{ test_api_kthread_self,   "[test][thread][api] thread identification       [passed]\n" },
-	{ test_api_kthread_create, "[test][thread][api] thread creation/termination [passed]\n" },
-	{ NULL,                     NULL                                                        },
+	{ test_api_kthread_self,   "[test][thread][api] thread identification       [passed]" },
+	{ test_api_kthread_create, "[test][thread][api] thread creation/termination [passed]" },
+	{ NULL,                     NULL                                                      },
 };
 
 /**
  * @brief Fault tests.
  */
 static struct test thread_mgmt_tests_fault[] = {
-	{ test_fault_kthread_create_invalid,  "[test][thread][fault] invalid thread create [passed]\n" },
-	{ test_fault_kthread_create_bad,      "[test][thread][fault] bad thread create     [passed]\n" },
-	{ test_fault_kthread_join_invalid,    "[test][thread][fault] invalid thread join   [passed]\n" },
-	{ test_fault_kthread_join_bad,        "[test][thread][fault] bad thread join       [passed]\n" },
-	{ NULL,                                NULL                                                    },
+	{ test_fault_kthread_create_invalid,  "[test][thread][fault] invalid thread create [passed]" },
+	{ test_fault_kthread_create_bad,      "[test][thread][fault] bad thread create     [passed]" },
+	{ test_fault_kthread_join_invalid,    "[test][thread][fault] invalid thread join   [passed]" },
+	{ test_fault_kthread_join_bad,        "[test][thread][fault] bad thread join       [passed]" },
+	{ NULL,                                NULL                                                  },
 };
 
 /**
@@ -237,10 +237,10 @@ static struct test thread_mgmt_tests_fault[] = {
  */
 static struct test thread_mgmt_tests_stress[] = {
 #if (UTEST_KTHREAD_STRESS)
-	{ test_fault_kthread_create_overflow, "[test][thread][stress] thread creation overflow    [passed]\n" },
-	{ test_stress_kthread_create,         "[test][thread][stress] thread creation/termination [passed]\n" },
+	{ test_fault_kthread_create_overflow, "[test][thread][stress] thread creation overflow    [passed]" },
+	{ test_stress_kthread_create,         "[test][thread][stress] thread creation/termination [passed]" },
 #endif
-	{ NULL,                                NULL                                                           },
+	{ NULL,                                NULL                                                         },
 };
 
 /**
@@ -251,7 +251,7 @@ static struct test thread_mgmt_tests_stress[] = {
 void test_thread_mgmt(void)
 {
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; thread_mgmt_tests_api[i].test_fn != NULL; i++)
 	{
 		thread_mgmt_tests_api[i].test_fn();
@@ -259,7 +259,7 @@ void test_thread_mgmt(void)
 	}
 
 	/* Fault Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; thread_mgmt_tests_fault[i].test_fn != NULL; i++)
 	{
 		thread_mgmt_tests_fault[i].test_fn();
@@ -267,7 +267,7 @@ void test_thread_mgmt(void)
 	}
 
 	/* Stress Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; thread_mgmt_tests_stress[i].test_fn != NULL; i++)
 	{
 		thread_mgmt_tests_stress[i].test_fn();

--- a/src/test/perf.c
+++ b/src/test/perf.c
@@ -70,10 +70,10 @@ void test_api_nanvix_perf_read(void)
  * @brief API tests.
  */
 static struct test perf_tests_api[] = {
-	{ test_api_nanvix_perf_query,      "[test][perf][api] query performance monitoring capabilities [passed]\n" },
-	{ test_api_nanvix_perf_start_stop, "[test][perf][api] start/stop performance monitor            [passed]\n" },
-	{ test_api_nanvix_perf_read,       "[test][perf][api] read performance monitor                  [passed]\n" },
-	{ NULL,                             NULL                                                                    },
+	{ test_api_nanvix_perf_query,      "[test][perf][api] query performance monitoring capabilities [passed]" },
+	{ test_api_nanvix_perf_start_stop, "[test][perf][api] start/stop performance monitor            [passed]" },
+	{ test_api_nanvix_perf_read,       "[test][perf][api] read performance monitor                  [passed]" },
+	{ NULL,                             NULL                                                                  },
 };
 
 #endif
@@ -93,7 +93,7 @@ void test_perf(void)
 #if (CORE_HAS_PERF)
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; perf_tests_api[i].test_fn != NULL; i++)
 	{
 		perf_tests_api[i].test_fn();

--- a/src/test/signal.c
+++ b/src/test/signal.c
@@ -80,8 +80,8 @@ void test_api_signal_action(void)
  * @brief API tests.
  */
 static struct test signal_tests_api[] = {
-	{ test_api_signal_action, "[test][signal][api] signal register/unregister [passed]\n" },
-	{ NULL,                    NULL                                                       },
+	{ test_api_signal_action, "[test][signal][api] signal register/unregister [passed]" },
+	{ NULL,                    NULL                                                     },
 };
 
 /*============================================================================*
@@ -121,8 +121,8 @@ void test_fault_signal_action(void)
  * @brief API tests.
  */
 static struct test signal_tests_fault[] = {
-	{ test_fault_signal_action, "[test][signal][fault] signal register/unregister [passed]\n" },
-	{ NULL,                      NULL                                                         },
+	{ test_fault_signal_action, "[test][signal][fault] signal register/unregister [passed]" },
+	{ NULL,                      NULL                                                       },
 };
 
 
@@ -138,7 +138,7 @@ void test_signal(void)
 {
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; signal_tests_api[i].test_fn != NULL; i++)
 	{
 		signal_tests_api[i].test_fn();
@@ -146,7 +146,7 @@ void test_signal(void)
 	}
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; signal_tests_fault[i].test_fn != NULL; i++)
 	{
 		signal_tests_fault[i].test_fn();

--- a/src/test/sleep.c
+++ b/src/test/sleep.c
@@ -200,16 +200,16 @@ static void test_stress_sleep_wakeup(void)
  * @brief API tests.
  */
 static struct test thread_sleep_tests_api[] = {
-	{ test_api_sleep_wakeup, "[test][thread][api] thread sleep/wakeup [passed]\n" },
-	{ NULL,                   NULL                                                },
+	{ test_api_sleep_wakeup, "[test][thread][api] thread sleep/wakeup [passed]" },
+	{ NULL,                   NULL                                              },
 };
 
 /**
  * @brief Fault injection tests.
  */
 static struct test thread_sleep_tests_fault[] = {
-	{ test_fault_sleep_wakeup, "[test][thread][fault] thread sleep/wakeup [passed]\n" },
-	{ NULL,                     NULL                                                  },
+	{ test_fault_sleep_wakeup, "[test][thread][fault] thread sleep/wakeup [passed]" },
+	{ NULL,                     NULL                                                },
 };
 
 /**
@@ -217,9 +217,9 @@ static struct test thread_sleep_tests_fault[] = {
  */
 static struct test thread_sleep_tests_stress[] = {
 #if UTEST_SLEEP_STRESS
-	{ test_stress_sleep_wakeup, "[test][thread][stress] thread sleep/wakeup [passed]\n" },
+	{ test_stress_sleep_wakeup, "[test][thread][stress] thread sleep/wakeup [passed]" },
 #endif
-	{ NULL,                      NULL                                                   },
+	{ NULL,                      NULL                                                 },
 };
 
 #endif
@@ -235,7 +235,7 @@ void test_thread_sleep(void)
 #if (THREAD_MAX > 2)
 
 	/* API Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; thread_sleep_tests_api[i].test_fn != NULL; i++)
 	{
 		thread_sleep_tests_api[i].test_fn();
@@ -243,7 +243,7 @@ void test_thread_sleep(void)
 	}
 
 	/* Fault Injection Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; thread_sleep_tests_fault[i].test_fn != NULL; i++)
 	{
 		thread_sleep_tests_fault[i].test_fn();
@@ -251,7 +251,7 @@ void test_thread_sleep(void)
 	}
 
 	/* Stress Tests */
-	nanvix_puts("--------------------------------------------------------------------------------\n");
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; thread_sleep_tests_stress[i].test_fn != NULL; i++)
 	{
 		thread_sleep_tests_stress[i].test_fn();


### PR DESCRIPTION
# Description
In this PR, tests to evaluate virtual to hardware synchronization points multiplexation were added. Namely:

- `test_api_sync_multiple_create_open()`: tests if it's possible to call `do_vsync_create` and `do_vsync_open` multiple times, limited only by `KSYNC_MAX`;