### PR TITLE
[test] KMailbox Multiplexation Tests

### DIFF
--- a/include/nanvix/sys/mailbox.h
+++ b/include/nanvix/sys/mailbox.h
@@ -37,23 +37,25 @@
 	 * @brief Creates an input mailbox.
 	 *
 	 * @param local Target local NoC node.
+	 * @param port  Target port in @p local NoC node.
 	 *
 	 * @return Upon successful completion, the ID of the created input
 	 * mailbox is returned. Upon failure, a negative error code is
 	 * returned instead.
 	 */
-	extern int kmailbox_create(int local);
+	extern int kmailbox_create(int local, int port);
 
 	/**
 	 * @brief Opens an output mailbox
 	 *
-	 * @param local Target remote NoC node.
+	 * @param remote      Target remote NoC node.
+	 * @param remote_port Target port in @p remote NoC node.
 	 *
 	 * @return Upon successful completion, the ID of the opened output
 	 * mailbox is returned. Upon failure, a negative error code is
 	 * returned instead.
 	 */
-	extern int kmailbox_open(int remote);
+	extern int kmailbox_open(int remote, int remote_port);
 
 	/**
 	 * @brief Removes an input mailbox.

--- a/src/libnanvix/ikc/stdmailbox.c
+++ b/src/libnanvix/ikc/stdmailbox.c
@@ -48,7 +48,7 @@ int __stdmailbox_setup(void)
 	tid = kthread_self();
 	local = knode_get_num();
 
-	return (((__stdinbox[tid] = kmailbox_create(local)) < 0) ? -1 : 0);
+	return (((__stdinbox[tid] = kmailbox_create(local, 0)) < 0) ? -1 : 0);
 }
 
 /**

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -43,17 +43,6 @@
 	#define SLAVE_NODENUM  1
 #endif
 
-/**
- * @brief Multiple open / create test parameters.
- */
-#define TEST_NR_INPUT_MAILBOXES   5
-#define TEST_NR_OUTPUT_MAILBOXES 15
-
-/**
- * @brief Multiplex test parameters.
- */
-#define TEST_NR_MAILBOX_PAIRS 5
-
 /*============================================================================*
  * API Test: Create Unlink                                                    *
  *============================================================================*/
@@ -68,7 +57,7 @@ static void test_api_mailbox_create_unlink(void)
 
 	local = knode_get_num();
 
-	test_assert((mbxid = kmailbox_create(local)) >= 0);
+	test_assert((mbxid = kmailbox_create(local, 0)) >= 0);
 	test_assert(kmailbox_unlink(mbxid) == 0);
 }
 
@@ -86,7 +75,7 @@ static void test_api_mailbox_open_close(void)
 
 	remote = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
-	test_assert((mbxid = kmailbox_open(remote)) >= 0);
+	test_assert((mbxid = kmailbox_open(remote, 0)) >= 0);
 	test_assert(kmailbox_close(mbxid) == 0);
 }
 
@@ -108,8 +97,8 @@ static void test_api_mailbox_get_volume(void)
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
-	test_assert((mbx_in = kmailbox_create(local)) >= 0);
-	test_assert((mbx_out = kmailbox_open(remote)) >= 0);
+	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
+	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
 
 		test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 		test_assert(volume == 0);
@@ -139,8 +128,8 @@ static void test_api_mailbox_get_latency(void)
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
-	test_assert((mbx_in = kmailbox_create(local)) >= 0);
-	test_assert((mbx_out = kmailbox_open(remote)) >= 0);
+	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
+	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
 
 		test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency == 0);
@@ -158,6 +147,8 @@ static void test_api_mailbox_get_latency(void)
 
 /**
  * @brief API Test: Read Write 2 CC
+ *
+ * @todo Uncomment kmailbox_wait() call when microkernel properly supports it.
  */
 static void test_api_mailbox_read_write(void)
 {
@@ -167,13 +158,13 @@ static void test_api_mailbox_read_write(void)
 	int mbx_out;
 	size_t volume;
 	uint64_t latency;
-	char message[MAILBOX_MSG_SIZE];
+	char message[KMAILBOX_MESSAGE_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
-	test_assert((mbx_in = kmailbox_create(local)) >= 0);
-	test_assert((mbx_out = kmailbox_open(remote)) >= 0);
+	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
+	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
 
 	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == 0);
@@ -189,44 +180,48 @@ static void test_api_mailbox_read_write(void)
 	{
 		for (unsigned i = 0; i < NITERATIONS; i++)
 		{
-			kmemset(message, 1, MAILBOX_MSG_SIZE);
+			kmemset(message, 1, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_awrite(mbx_out, message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_awrite(mbx_out, message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-			kmemset(message, 0, MAILBOX_MSG_SIZE);
+			kmemset(message, 0, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_aread(mbx_in, message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_aread(mbx_in, message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		#if 0
 			test_assert(kmailbox_wait(mbx_in) == 0);
+		#endif
 
-			for (unsigned j = 0; j < MAILBOX_MSG_SIZE; ++j)
+			for (unsigned j = 0; j < KMAILBOX_MESSAGE_SIZE; ++j)
 				test_assert(message[j] == 2);
 		}
 	}
-	else
+	else if (local == SLAVE_NODENUM)
 	{
 		for (unsigned i = 0; i < NITERATIONS; i++)
 		{
-			kmemset(message, 0, MAILBOX_MSG_SIZE);
+			kmemset(message, 0, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_aread(mbx_in, message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_aread(mbx_in, message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		#if 0
 			test_assert(kmailbox_wait(mbx_in) == 0);
+		#endif
 
-			for (unsigned j = 0; j < MAILBOX_MSG_SIZE; ++j)
+			for (unsigned j = 0; j < KMAILBOX_MESSAGE_SIZE; ++j)
 				test_assert(message[j] == 1);
 
-			kmemset(message, 2, MAILBOX_MSG_SIZE);
+			kmemset(message, 2, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_awrite(mbx_out, message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_awrite(mbx_out, message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 		}
 	}
 
 	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MAILBOX_MSG_SIZE));
+	test_assert(volume == (NITERATIONS * KMAILBOX_MESSAGE_SIZE));
 	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
 	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MAILBOX_MSG_SIZE));
+	test_assert(volume == (NITERATIONS * KMAILBOX_MESSAGE_SIZE));
 	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
@@ -235,119 +230,404 @@ static void test_api_mailbox_read_write(void)
 }
 
 /*============================================================================*
- * API Test: Multiple create / open                                           *
+ * API Test: Virtualization                                                   *
  *============================================================================*/
 
+#define TEST_VIRTUALIZATION_MBX_NR 10
+
 /**
- * @brief API Test: Multiple create / open of virtual mailboxes.
+ * @brief API Test: Virtualization.
  */
-static void test_api_mailbox_multiple_create_open(void)
+static void test_api_mailbox_virtualization(void)
 {
 	int local;
 	int remote;
-	int mbx_in[TEST_NR_INPUT_MAILBOXES];
-	int mbx_out[TEST_NR_OUTPUT_MAILBOXES];
+	int mbx_in[TEST_VIRTUALIZATION_MBX_NR];
+	int mbx_out[TEST_VIRTUALIZATION_MBX_NR];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
 	/* Creates multiple virtual mailboxes. */
-	for (unsigned i = 0; i < TEST_NR_INPUT_MAILBOXES; ++i)
-		test_assert((mbx_in[i] = kmailbox_create(local)) >= 0);
-
-	for (unsigned i = 0; i < TEST_NR_OUTPUT_MAILBOXES; ++i)
-		test_assert((mbx_out[i] = kmailbox_open(remote)) >= 0);
+	for (unsigned i = 0; i < TEST_VIRTUALIZATION_MBX_NR; ++i)
+	{
+		test_assert((mbx_in[i] = kmailbox_create(local, i)) >= 0);
+		test_assert((mbx_out[i] = kmailbox_open(remote, i)) >= 0);
+	}
 
 	/* Deletion of the created virtual mailboxes. */
-	for (unsigned i = 0; i < TEST_NR_INPUT_MAILBOXES; ++i)
+	for (unsigned i = 0; i < TEST_VIRTUALIZATION_MBX_NR; ++i)
+	{
 		test_assert(kmailbox_unlink(mbx_in[i]) == 0);
-
-	for (unsigned i = 0; i < TEST_NR_OUTPUT_MAILBOXES; ++i)
 		test_assert(kmailbox_close(mbx_out[i]) == 0);
+	}
 }
 
 /*============================================================================*
- * API Test: Multiplex                                                        *
+ * API Test: Multiplexation                                                   *
  *============================================================================*/
+
+#define TEST_MULTIPLEXATION_MBX_PAIRS 5
 
 /**
  * @brief API Test: Multiplex of virtual to hardware mailboxes.
+ *
+ * @todo Uncomment kmailbox_wait() call when microkernel properly supports it.
  */
-static void test_api_mailbox_multiplex(void)
+static void test_api_mailbox_multiplexation(void)
 {
 	int local;
 	int remote;
 	size_t volume;
 	uint64_t latency;
-	int mbx_in[TEST_NR_MAILBOX_PAIRS];
-	int mbx_out[TEST_NR_MAILBOX_PAIRS];
-	char message[MAILBOX_MSG_SIZE];
+	int mbx_in[TEST_MULTIPLEXATION_MBX_PAIRS];
+	int mbx_out[TEST_MULTIPLEXATION_MBX_PAIRS];
+	char message[KMAILBOX_MESSAGE_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
 	/* Creates multiple virtual mailboxes. */
-	for (unsigned i = 0; i < TEST_NR_MAILBOX_PAIRS; ++i)
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION_MBX_PAIRS; ++i)
 	{
-		test_assert((mbx_in[i] = kmailbox_create(local)) >= 0);
-		test_assert((mbx_out[i] = kmailbox_open(remote)) >= 0);
+		test_assert((mbx_in[i] = kmailbox_create(local, i)) >= 0);
+		test_assert((mbx_out[i] = kmailbox_open(remote, i)) >= 0);
 	}
 
 	/* Multiple write/read operations to test multiplex. */
 	if (local == MASTER_NODENUM)
 	{
-		for (unsigned i = 0; i < TEST_NR_MAILBOX_PAIRS; ++i)
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION_MBX_PAIRS; ++i)
 		{
-			kmemset(message, i, MAILBOX_MSG_SIZE);
+			kmemset(message, i, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_awrite(mbx_out[i], message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_awrite(mbx_out[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-			kmemset(message, 0, MAILBOX_MSG_SIZE);
+			kmemset(message, 0, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_aread(mbx_in[i], message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_aread(mbx_in[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		#if 0
 			test_assert(kmailbox_wait(mbx_in[i]) == 0);
+		#endif
 
-			for (unsigned j = 0; j < MAILBOX_MSG_SIZE; ++j)
+			for (unsigned j = 0; j < KMAILBOX_MESSAGE_SIZE; ++j)
 				test_assert(message[j] - (i + 1) == 0);
 		}
 	}
-	else
+	else if (local == SLAVE_NODENUM)
 	{
-		for (unsigned i = 0; i < TEST_NR_MAILBOX_PAIRS; ++i)
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION_MBX_PAIRS; ++i)
 		{
-			kmemset(message, 0, MAILBOX_MSG_SIZE);
+			kmemset(message, 0, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_aread(mbx_in[i], message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_aread(mbx_in[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		#if 0
 			test_assert(kmailbox_wait(mbx_in[i]) == 0);
+		#endif
 
-			for (unsigned j = 0; j < MAILBOX_MSG_SIZE; ++j)
+			for (unsigned j = 0; j < KMAILBOX_MESSAGE_SIZE; ++j)
 				test_assert(message[j] - i == 0);
 
-			kmemset(message, i + 1, MAILBOX_MSG_SIZE);
+			kmemset(message, i + 1, KMAILBOX_MESSAGE_SIZE);
 
-			test_assert(kmailbox_awrite(mbx_out[i], message, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
+			test_assert(kmailbox_awrite(mbx_out[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 		}
 	}
 
 	/* Checks the data volume transferred by each vmailbox. */
-	for (unsigned i = 0; i < TEST_NR_MAILBOX_PAIRS; ++i)
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION_MBX_PAIRS; ++i)
 	{
 		test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MAILBOX_MSG_SIZE);
+		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
 		test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 
 		test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MAILBOX_MSG_SIZE);
+		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
 		test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 	}
 
-	/* Deletion of the created virtual mailboxes. */
-	for (unsigned i = 0; i < TEST_NR_MAILBOX_PAIRS; ++i)
+	/* Closes the used vmailboxes. */
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION_MBX_PAIRS; ++i)
 	{
 		test_assert(kmailbox_unlink(mbx_in[i]) == 0);
 		test_assert(kmailbox_close(mbx_out[i]) == 0);
+	}
+}
+
+/*============================================================================*
+ * API Test: Multiplexation - Out of Order                                    *
+ *============================================================================*/
+
+#define TEST_MULTIPLEXATION2_MBX_PAIRS 3
+
+/**
+ * @brief API Test: Multiplexation test to assert the correct working when
+ * messages flow occur in diferent order than the expected.
+ *
+ * @todo Uncomment kmailbox_wait() call when microkernel properly supports it.
+ */
+static void test_api_mailbox_multiplexation_2(void)
+{
+	int local;
+	int remote;
+	size_t volume;
+	uint64_t latency;
+	int mbx_in[TEST_MULTIPLEXATION2_MBX_PAIRS];
+	int mbx_out[TEST_MULTIPLEXATION2_MBX_PAIRS];
+	char message[KMAILBOX_MESSAGE_SIZE];
+
+	local  = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION2_MBX_PAIRS; ++i)
+	{
+		test_assert((mbx_in[i] = kmailbox_create(local, i)) >= 0);
+		test_assert((mbx_out[i] = kmailbox_open(remote, i)) >= 0);
+	}
+
+	if (local == MASTER_NODENUM)
+	{
+		/* Writes data in descendant order. */
+		for (int i = (TEST_MULTIPLEXATION2_MBX_PAIRS - 1); i >= 0; --i)
+		{
+			kmemset(message, i, KMAILBOX_MESSAGE_SIZE);
+
+			test_assert(kmailbox_awrite(mbx_out[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		}
+
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_MBX_PAIRS; ++i)
+		{
+			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
+			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(latency > 0);
+		}
+	}
+	else if (local == SLAVE_NODENUM)
+	{
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_MBX_PAIRS; ++i)
+		{
+			kmemset(message, -1, KMAILBOX_MESSAGE_SIZE);
+
+			test_assert(kmailbox_aread(mbx_in[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		#if 0
+			test_assert(kmailbox_wait(mbx_in[i]) == 0);
+		#endif
+
+			for (unsigned j = 0; j < KMAILBOX_MESSAGE_SIZE; ++j)
+				test_assert((message[j] - i) == 0);
+		}
+
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_MBX_PAIRS; ++i)
+		{
+			test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
+		}
+	}
+
+	/* Synchronization message. */
+	if (local == MASTER_NODENUM)
+	{
+		test_assert(kmailbox_aread(mbx_in[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+	}
+	else
+		test_assert(kmailbox_awrite(mbx_out[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+
+	/* Closes the used vmailboxes. */
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION2_MBX_PAIRS; ++i)
+	{
+		test_assert(kmailbox_unlink(mbx_in[i]) == 0);
+		test_assert(kmailbox_close(mbx_out[i]) == 0);
+	}
+}
+
+/*============================================================================*
+ * API Test: Multiplexation - Multiple Messages                               *
+ *============================================================================*/
+
+#define TEST_MULTIPLEXATION3_MBX_PAIRS 4
+
+/**
+ * @brief API Test: Multiplexation test to assert the message buffers tab
+ * solution to support multiple messages on the same port simultaneously.
+ *
+ * @details In this test, the MASTER sends 4 messages to 2 ports of the SLAVE.
+ * The reads in the master are also made out of order to assure that there are
+ * 2 messages queued for each vmailbox on SLAVE.
+ *
+ * @todo Uncomment kmailbox_wait() call when microkernel properly supports it.
+ */
+static void test_api_mailbox_multiplexation_3(void)
+{
+	int local;
+	int remote;
+	size_t volume;
+	uint64_t latency;
+	int mbx_in[TEST_MULTIPLEXATION3_MBX_PAIRS];
+	int mbx_out[TEST_MULTIPLEXATION3_MBX_PAIRS];
+	char message[KMAILBOX_MESSAGE_SIZE];
+
+	local  = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION3_MBX_PAIRS; ++i)
+	{
+		test_assert((mbx_in[i] = kmailbox_create(local, i)) >= 0);
+		test_assert((mbx_out[i] = kmailbox_open(remote, (int) (i/2))) >= 0);
+	}
+
+	/* Multiple write/read operations to test multiplex. */
+	if (local == MASTER_NODENUM)
+	{
+		for (int i = 0; i < TEST_MULTIPLEXATION3_MBX_PAIRS; ++i)
+		{
+			kmemset(message, (int) (i/2), KMAILBOX_MESSAGE_SIZE);
+
+			test_assert(kmailbox_awrite(mbx_out[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		}
+
+		/* Checks the data volume transfered by each mailbox. */
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_MBX_PAIRS; ++i)
+		{
+			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
+			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(latency > 0);
+		}
+	}
+	else if (local == SLAVE_NODENUM)
+	{
+		/* For each vmailbox. */
+		for (int i = 1; i >= 0; --i)
+		{
+			/* For each message (2 for each vmailbox). */
+			for (int j = 0; j < 2; ++j)
+			{
+				kmemset(message, -1, KMAILBOX_MESSAGE_SIZE);
+
+				test_assert(kmailbox_aread(mbx_in[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+			#if 0
+				test_assert(kmailbox_wait(mbx_in[i]) == 0);
+			#endif
+
+				for (unsigned k = 0; k < KMAILBOX_MESSAGE_SIZE; ++k)
+					test_assert((message[k] - i) == 0);
+			}
+		}
+
+		/* Checks the data volume transfered by each mailbox. */
+		for (unsigned i = 0; i < 2; ++i)
+		{
+			test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == (KMAILBOX_MESSAGE_SIZE * 2));
+		}
+	}
+
+	/* Synchronization message. */
+	if (local == MASTER_NODENUM)
+	{
+		test_assert(kmailbox_aread(mbx_in[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+	}
+	else
+		test_assert(kmailbox_awrite(mbx_out[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+
+	/* Closes the used vmailboxes. */
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION3_MBX_PAIRS; ++i)
+	{
+		test_assert(kmailbox_unlink(mbx_in[i]) == 0);
+		test_assert(kmailbox_close(mbx_out[i]) == 0);
+	}
+}
+
+/*============================================================================*
+ * API Test: Pending Messages - Unlink                                        *
+ *============================================================================*/
+
+#define TEST_PENDING_UNLINK_MBX_PAIRS 2
+
+/**
+ * @brief API Test: Test to assert if the kernel correctly avoids an unlink
+ * call when there still messages addressed to the target vportal on message
+ * buffers tab.
+ *
+ * @todo Uncomment kmailbox_wait() call when microkernel properly supports it.
+ */
+static void test_api_mailbox_pending_msg_unlink(void)
+{
+	int local;
+	int remote;
+	size_t volume;
+	uint64_t latency;
+	int mbx_in[TEST_PENDING_UNLINK_MBX_PAIRS];
+	int mbx_out[TEST_PENDING_UNLINK_MBX_PAIRS];
+	char message[KMAILBOX_MESSAGE_SIZE];
+
+	local  = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	for (unsigned i = 0; i < TEST_PENDING_UNLINK_MBX_PAIRS; ++i)
+	{
+		test_assert((mbx_in[i] = kmailbox_create(local, i)) >= 0);
+		test_assert((mbx_out[i] = kmailbox_open(remote, i)) >= 0);
+	}
+
+	/* Multiple write/read operations to test multiplex. */
+	if (local == MASTER_NODENUM)
+	{
+		for (int i = 0; i < TEST_PENDING_UNLINK_MBX_PAIRS; ++i)
+			test_assert(kmailbox_awrite(mbx_out[i], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+
+		/* Checks the data volume transfered by each mailbox. */
+		for (unsigned i = 0; i < TEST_PENDING_UNLINK_MBX_PAIRS; ++i)
+		{
+			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
+			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(latency > 0);
+
+			test_assert(kmailbox_close(mbx_out[i]) == 0);
+		}
+	}
+	else if (local == SLAVE_NODENUM)
+	{
+		test_assert(kmailbox_aread(mbx_in[1], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+	#if 0
+		test_assert(kmailbox_wait(mbx_in[1]) == 0);
+	#endif
+
+		test_assert(kmailbox_ioctl(mbx_in[1], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
+
+		test_assert(kmailbox_unlink(mbx_in[1]) == 0);
+
+
+		test_assert(kmailbox_unlink(mbx_in[0]) == -EBUSY);
+
+		test_assert(kmailbox_aread(mbx_in[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+	#if 0
+		test_assert(kmailbox_wait(mbx_in[0]) == 0);
+	#endif
+
+		test_assert(kmailbox_ioctl(mbx_in[0], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
+
+		test_assert(kmailbox_unlink(mbx_in[0]) == 0);
+	}
+
+	/* Synchronization message + closes the used vmailboxes. */
+	if (local == MASTER_NODENUM)
+	{
+		test_assert(kmailbox_aread(mbx_in[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		for (unsigned i = 0; i < TEST_PENDING_UNLINK_MBX_PAIRS; ++i)
+			test_assert(kmailbox_unlink(mbx_in[i]) == 0);
+	}
+	else
+	{
+		test_assert(kmailbox_awrite(mbx_out[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
+		for (unsigned i = 0; i < TEST_PENDING_UNLINK_MBX_PAIRS; ++i)
+			test_assert(kmailbox_close(mbx_out[i]) == 0);
 	}
 }
 
@@ -360,8 +640,31 @@ static void test_api_mailbox_multiplex(void)
  */
 static void test_fault_mailbox_invalid_create(void)
 {
-	test_assert(kmailbox_create(-1) == -EINVAL);
-	test_assert(kmailbox_create(PROCESSOR_NOC_NODES_NUM) == -EINVAL);
+	int nodenum = knode_get_num();
+
+	test_assert(kmailbox_create(-1, 0) == -EINVAL);
+	test_assert(kmailbox_create(PROCESSOR_NOC_NODES_NUM, 0) == -EINVAL);
+	test_assert(kmailbox_create(nodenum, -1) == -EINVAL);
+	test_assert(kmailbox_create(nodenum, MAILBOX_PORT_NR) == -EINVAL);
+}
+
+/*============================================================================*
+ * Fault Test: Double Create                                                  *
+ *============================================================================*/
+
+/**
+ * @brief Fault Test: Double Create
+ */
+static void test_fault_mailbox_double_create(void)
+{
+	int mbx;
+	int nodenum = knode_get_num();
+
+	test_assert((mbx = kmailbox_create(nodenum, 0)) >= 0);
+
+	test_assert(kmailbox_create(nodenum, 0) == -EBUSY);
+
+	test_assert(kmailbox_unlink(mbx) == 0);
 }
 
 /*============================================================================*
@@ -377,7 +680,7 @@ static void test_fault_mailbox_bad_create(void)
 
 	nodenum = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
-	test_assert(kmailbox_create(nodenum) == -EINVAL);
+	test_assert(kmailbox_create(nodenum, 0) == -EINVAL);
 }
 
 /*============================================================================*
@@ -390,8 +693,7 @@ static void test_fault_mailbox_bad_create(void)
 static void test_fault_mailbox_invalid_unlink(void)
 {
 	test_assert(kmailbox_unlink(-1) == -EINVAL);
-	test_assert(kmailbox_unlink(MAILBOX_CREATE_MAX) == -EBADF);
-	test_assert(kmailbox_unlink(1000000) == -EINVAL);
+	test_assert(kmailbox_unlink(KMAILBOX_MAX) == -EINVAL);
 }
 
 /*============================================================================*
@@ -404,13 +706,38 @@ static void test_fault_mailbox_invalid_unlink(void)
 static void test_fault_mailbox_double_unlink(void)
 {
 	int local;
-	int mbxid;
+	int mbxid1;
+	int mbxid2;
 
 	local = knode_get_num();
 
-	test_assert((mbxid = kmailbox_create(local)) >= 0);
-	test_assert(kmailbox_unlink(mbxid) == 0);
+	test_assert((mbxid1 = kmailbox_create(local, 0)) >= 0);
+	test_assert((mbxid2 = kmailbox_create(local, 1)) >= 0);
+
+	test_assert(kmailbox_unlink(mbxid1) == 0);
+	test_assert(kmailbox_unlink(mbxid1) == -EBADF);
+	test_assert(kmailbox_unlink(mbxid2) == 0);
+}
+
+/*============================================================================*
+ * Fault Test: Bad Unlink                                                     *
+ *============================================================================*/
+
+/**
+ * @brief Fault Test: Bad Unlink
+ */
+static void test_fault_mailbox_bad_unlink(void)
+{
+	int remote;
+	int mbxid;
+
+	remote = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	test_assert((mbxid = kmailbox_open(remote, 0)) >= 0);
+
 	test_assert(kmailbox_unlink(mbxid) == -EBADF);
+
+	test_assert(kmailbox_close(mbxid) == 0);
 }
 
 /*============================================================================*
@@ -422,8 +749,14 @@ static void test_fault_mailbox_double_unlink(void)
  */
 static void test_fault_mailbox_invalid_open(void)
 {
-	test_assert(kmailbox_open(-1) == -EINVAL);
-	test_assert(kmailbox_open(PROCESSOR_NOC_NODES_NUM) == -EINVAL);
+	int nodenum;
+
+	nodenum = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	test_assert(kmailbox_open(-1, 0) == -EINVAL);
+	test_assert(kmailbox_open(PROCESSOR_NOC_NODES_NUM, 0) == -EINVAL);
+	test_assert(kmailbox_open(nodenum, -1) == -EINVAL);
+	test_assert(kmailbox_open(nodenum, MAILBOX_PORT_NR) == -EINVAL);
 }
 
 /*============================================================================*
@@ -442,7 +775,7 @@ static void test_fault_mailbox_bad_open(void)
 #ifdef __mppa256__
 	if (processor_noc_is_cnode(nodenum))
 #endif
-		test_assert(kmailbox_open(nodenum) == -EINVAL);
+		test_assert(kmailbox_open(nodenum, 0) == -EINVAL);
 }
 
 /*============================================================================*
@@ -455,8 +788,7 @@ static void test_fault_mailbox_bad_open(void)
 static void test_fault_mailbox_invalid_close(void)
 {
 	test_assert(kmailbox_close(-1) == -EINVAL);
-	test_assert(kmailbox_close(MAILBOX_OPEN_MAX) == -EBADF);
-	test_assert(kmailbox_close(1000000) == -EINVAL);
+	test_assert(kmailbox_close(KMAILBOX_MAX) == -EINVAL);
 }
 
 /*============================================================================*
@@ -468,14 +800,18 @@ static void test_fault_mailbox_invalid_close(void)
  */
 static void test_fault_mailbox_double_close(void)
 {
-	int mbxid;
+	int mbxid1;
+	int mbxid2;
 	int nodenum;
 
 	nodenum = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
-	test_assert((mbxid = kmailbox_open(nodenum)) >= 0);
-	test_assert(kmailbox_close(mbxid) == 0);
-	test_assert(kmailbox_close(mbxid) == -EBADF);
+	test_assert((mbxid1 = kmailbox_open(nodenum, 0)) >= 0);
+	test_assert((mbxid2 = kmailbox_open(nodenum, 1)) >= 0);
+
+	test_assert(kmailbox_close(mbxid1) == 0);
+	test_assert(kmailbox_close(mbxid1) == -EBADF);
+	test_assert(kmailbox_close(mbxid2) == 0);
 }
 
 /*============================================================================*
@@ -492,9 +828,9 @@ static void test_fault_mailbox_bad_close(void)
 
 	local = knode_get_num();
 
-	test_assert((mbxid = kmailbox_create(local)) >= 0);
+	test_assert((mbxid = kmailbox_create(local, 0)) >= 0);
 
-		test_assert(kmailbox_close(mbxid) == -EBADF);
+	test_assert(kmailbox_close(mbxid) == -EBADF);
 
 	test_assert(kmailbox_unlink(mbxid) == 0);
 }
@@ -508,11 +844,32 @@ static void test_fault_mailbox_bad_close(void)
  */
 static void test_fault_mailbox_invalid_read(void)
 {
-	char buffer[MAILBOX_MSG_SIZE];
+	char buffer[KMAILBOX_MESSAGE_SIZE];
 
-	test_assert(kmailbox_aread(-1, buffer, MAILBOX_MSG_SIZE) == -EINVAL);
-	test_assert(kmailbox_aread(MAILBOX_CREATE_MAX, buffer, MAILBOX_MSG_SIZE) == -EBADF);
-	test_assert(kmailbox_aread(1000000, buffer, MAILBOX_MSG_SIZE) == -EINVAL);
+	test_assert(kmailbox_aread(-1, buffer, KMAILBOX_MESSAGE_SIZE) == -EINVAL);
+	test_assert(kmailbox_aread(KMAILBOX_MAX, buffer, KMAILBOX_MESSAGE_SIZE) == -EINVAL);
+}
+
+/*============================================================================*
+ * Fault Test: Bad Read                                                       *
+ *============================================================================*/
+
+/**
+ * @brief Fault Test: Bad Read
+ */
+static void test_fault_mailbox_bad_read(void)
+{
+	int mbxid;
+	int nodenum;
+	char buffer[KMAILBOX_MESSAGE_SIZE];
+
+	nodenum = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	test_assert((mbxid = kmailbox_open(nodenum, 0)) >= 0);
+
+	test_assert(kmailbox_aread(mbxid, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
+
+	test_assert(kmailbox_close(mbxid) == 0);
 }
 
 /*============================================================================*
@@ -526,16 +883,16 @@ static void test_fault_mailbox_invalid_read_size(void)
 {
 	int mbxid;
 	int local;
-	char buffer[MAILBOX_MSG_SIZE];
+	char buffer[KMAILBOX_MESSAGE_SIZE];
 
 	local = knode_get_num();
 
-	test_assert((mbxid = kmailbox_create(local)) >= 0);
+	test_assert((mbxid = kmailbox_create(local, 0)) >= 0);
 
 		test_assert(kmailbox_aread(mbxid, buffer, -1) == -EINVAL);
 		test_assert(kmailbox_aread(mbxid, buffer, 0) == -EINVAL);
-		test_assert(kmailbox_aread(mbxid, buffer, MAILBOX_MSG_SIZE - 1) == -EINVAL);
-		test_assert(kmailbox_aread(mbxid, buffer, MAILBOX_MSG_SIZE + 1) == -EINVAL);
+		test_assert(kmailbox_aread(mbxid, buffer, KMAILBOX_MESSAGE_SIZE - 1) == -EINVAL);
+		test_assert(kmailbox_aread(mbxid, buffer, KMAILBOX_MESSAGE_SIZE + 1) == -EINVAL);
 
 	test_assert(kmailbox_unlink(mbxid) == 0);
 }
@@ -554,9 +911,9 @@ static void test_fault_mailbox_null_read(void)
 
 	local = knode_get_num();
 
-	test_assert((mbxid = kmailbox_create(local)) >= 0);
+	test_assert((mbxid = kmailbox_create(local, 0)) >= 0);
 
-		test_assert(kmailbox_aread(mbxid, NULL, MAILBOX_MSG_SIZE) == -EINVAL);
+		test_assert(kmailbox_aread(mbxid, NULL, KMAILBOX_MESSAGE_SIZE) == -EINVAL);
 
 	test_assert(kmailbox_unlink(mbxid) == 0);
 }
@@ -570,11 +927,10 @@ static void test_fault_mailbox_null_read(void)
  */
 static void test_fault_mailbox_invalid_write(void)
 {
-	char buffer[MAILBOX_MSG_SIZE];
+	char buffer[KMAILBOX_MESSAGE_SIZE];
 
-	test_assert(kmailbox_awrite(-1, buffer, MAILBOX_MSG_SIZE) == -EINVAL);
-	test_assert(kmailbox_awrite(MAILBOX_OPEN_MAX, buffer, MAILBOX_MSG_SIZE) == -EBADF);
-	test_assert(kmailbox_awrite(1000000, buffer, MAILBOX_MSG_SIZE) == -EINVAL);
+	test_assert(kmailbox_awrite(-1, buffer, KMAILBOX_MESSAGE_SIZE) == -EINVAL);
+	test_assert(kmailbox_awrite(KMAILBOX_MAX, buffer, KMAILBOX_MESSAGE_SIZE) == -EINVAL);
 }
 
 /*============================================================================*
@@ -588,32 +944,74 @@ static void test_fault_mailbox_bad_write(void)
 {
 	int mbxid;
 	int local;
-	char buffer[MAILBOX_MSG_SIZE];
+	char buffer[KMAILBOX_MESSAGE_SIZE];
 
 	local = knode_get_num();
 
-	test_assert((mbxid = kmailbox_create(local)) >= 0);
+	test_assert((mbxid = kmailbox_create(local, 0)) >= 0);
 
-		test_assert(kmailbox_awrite(mbxid, buffer, MAILBOX_MSG_SIZE) == -EBADF);
+		test_assert(kmailbox_awrite(mbxid, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
 
 	test_assert(kmailbox_unlink(mbxid) == 0);
 }
 
 /*============================================================================*
- * Fault Test: Bad Wait                                                       *
+ * Fault Test: Invalid Write Size                                             *
  *============================================================================*/
 
 /**
- * @brief Fault Test: Bad Write
+ * @brief Fault Test: Invalid Write Size
  */
-static void test_fault_mailbox_bad_wait(void)
+static void test_fault_mailbox_invalid_write_size(void)
+{
+	int mbxid;
+	int remote;
+	char buffer[KMAILBOX_MESSAGE_SIZE];
+
+	remote = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	test_assert((mbxid = kmailbox_open(remote, 0)) >= 0);
+
+		test_assert(kmailbox_awrite(mbxid, buffer, -1) == -EINVAL);
+		test_assert(kmailbox_awrite(mbxid, buffer, 0) == -EINVAL);
+		test_assert(kmailbox_awrite(mbxid, buffer, KMAILBOX_MESSAGE_SIZE - 1) == -EINVAL);
+		test_assert(kmailbox_awrite(mbxid, buffer, KMAILBOX_MESSAGE_SIZE + 1) == -EINVAL);
+
+	test_assert(kmailbox_close(mbxid) == 0);
+}
+
+/*============================================================================*
+ * Fault Test: Null Write                                                     *
+ *============================================================================*/
+
+/**
+ * @brief Fault Test: Null Write
+ */
+static void test_fault_mailbox_null_write(void)
+{
+	int mbxid;
+	int remote;
+
+	remote = (knode_get_num() == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	test_assert((mbxid = kmailbox_open(remote, 0)) >= 0);
+
+		test_assert(kmailbox_awrite(mbxid, NULL, KMAILBOX_MESSAGE_SIZE) == -EINVAL);
+
+	test_assert(kmailbox_close(mbxid) == 0);
+}
+
+/*============================================================================*
+ * Fault Test: Invalid Wait                                                   *
+ *============================================================================*/
+
+/**
+ * @brief Fault Test: Invalid Wait
+ */
+static void test_fault_mailbox_invalid_wait(void)
 {
 	test_assert(kmailbox_wait(-1) == -EINVAL);
-#ifndef __unix64__
-	test_assert(kmailbox_wait(MAILBOX_CREATE_MAX) == -EBADF);
-	test_assert(kmailbox_wait(MAILBOX_OPEN_MAX) == -EBADF);
-#endif
-	test_assert(kmailbox_wait(1000000) == -EINVAL);
+	test_assert(kmailbox_wait(KMAILBOX_MAX) == -EINVAL);
 }
 
 /*============================================================================*
@@ -632,12 +1030,12 @@ static void test_fault_mailbox_invalid_ioctl(void)
 
 	test_assert(kmailbox_ioctl(-1, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EINVAL);
 	test_assert(kmailbox_ioctl(-1, MAILBOX_IOCTL_GET_LATENCY, &latency) == -EINVAL);
-	test_assert(kmailbox_ioctl(1000000, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EINVAL);
-	test_assert(kmailbox_ioctl(1000000, MAILBOX_IOCTL_GET_LATENCY, &latency) == -EINVAL);
+	test_assert(kmailbox_ioctl(KMAILBOX_MAX, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EINVAL);
+	test_assert(kmailbox_ioctl(KMAILBOX_MAX, MAILBOX_IOCTL_GET_LATENCY, &latency) == -EINVAL);
 
 	local = knode_get_num();
 
-	test_assert((mbxid = kmailbox_create(local)) >=  0);
+	test_assert((mbxid = kmailbox_create(local, 0)) >= 0);
 
 		test_assert(kmailbox_ioctl(mbxid, -1, &volume) == -ENOTSUP);
 
@@ -645,17 +1043,36 @@ static void test_fault_mailbox_invalid_ioctl(void)
 }
 
 /*============================================================================*
- * Fault Test: Bad ioctl                                                      *
+ * Fault Test: Bad mbxid                                                      *
  *============================================================================*/
 
 /**
- * @brief Fault Test: Bad ioctl
+ * @brief Fault Test: Bad mbxid
  */
-static void test_fault_mailbox_bad_ioctl(void)
+static void test_fault_mailbox_bad_mbxid(void)
 {
+	int mbx_in;
+	int mbx_out;
+	int remote;
+	int local;
 	size_t volume;
+	char buffer[KMAILBOX_MESSAGE_SIZE];
 
-	test_assert(kmailbox_ioctl(0, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EBADF);
+	local = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
+	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
+
+	test_assert(kmailbox_close(mbx_out + 1) == -EBADF);
+	test_assert(kmailbox_unlink(mbx_in + 1) == -EBADF);
+	test_assert(kmailbox_aread(mbx_in + 1, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
+	test_assert(kmailbox_awrite(mbx_in + 1, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
+	test_assert(kmailbox_wait(mbx_in + 1) == -EBADF);
+	test_assert(kmailbox_ioctl(mbx_in + 1, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EBADF);
+
+	test_assert(kmailbox_close(mbx_out) == 0);
+	test_assert(kmailbox_unlink(mbx_in) == 0);
 }
 
 /*============================================================================*
@@ -666,38 +1083,46 @@ static void test_fault_mailbox_bad_ioctl(void)
  * @brief Unit tests.
  */
 static struct test mailbox_tests_api[] = {
-	{ test_api_mailbox_create_unlink,        "[test][mailbox][api] mailbox create unlink        [passed]" },
-	{ test_api_mailbox_open_close,           "[test][mailbox][api] mailbox open close           [passed]" },
-	{ test_api_mailbox_get_volume,           "[test][mailbox][api] mailbox get volume           [passed]" },
-	{ test_api_mailbox_get_latency,          "[test][mailbox][api] mailbox get latency          [passed]" },
-	{ test_api_mailbox_read_write,           "[test][mailbox][api] mailbox read write           [passed]" },
-	{ test_api_mailbox_multiple_create_open, "[test][mailbox][api] mailbox multiple create open [passed]" },
-	{ test_api_mailbox_multiplex,            "[test][mailbox][api] mailbox multiplex            [passed]" },
-	{ NULL,                                   NULL                                                        },
+	{ test_api_mailbox_create_unlink,      "[test][mailbox][api] mailbox create unlink      [passed]" },
+	{ test_api_mailbox_open_close,         "[test][mailbox][api] mailbox open close         [passed]" },
+	{ test_api_mailbox_get_volume,         "[test][mailbox][api] mailbox get volume         [passed]" },
+	{ test_api_mailbox_get_latency,        "[test][mailbox][api] mailbox get latency        [passed]" },
+	{ test_api_mailbox_read_write,         "[test][mailbox][api] mailbox read write         [passed]" },
+	{ test_api_mailbox_virtualization,     "[test][mailbox][api] mailbox virtualization     [passed]" },
+	{ test_api_mailbox_multiplexation,     "[test][mailbox][api] mailbox multiplexation     [passed]" },
+	{ test_api_mailbox_multiplexation_2,   "[test][mailbox][api] mailbox multiplexation 2   [passed]" },
+	{ test_api_mailbox_multiplexation_3,   "[test][mailbox][api] mailbox multiplexation 3   [passed]" },
+	{ test_api_mailbox_pending_msg_unlink, "[test][mailbox][api] mailbox pending msg unlink [passed]" },
+	{ NULL,                                 NULL                                                      },
 };
 
 /**
  * @brief Unit tests.
  */
 static struct test mailbox_tests_fault[] = {
-	{ test_fault_mailbox_invalid_create,    "[test][mailbox][fault] mailbox invalid create    [passed]" },
-	{ test_fault_mailbox_bad_create,        "[test][mailbox][fault] mailbox bad create        [passed]" },
-	{ test_fault_mailbox_invalid_unlink,    "[test][mailbox][fault] mailbox invalid unlink    [passed]" },
-	{ test_fault_mailbox_double_unlink,     "[test][mailbox][fault] mailbox double unlink     [passed]" },
-	{ test_fault_mailbox_invalid_open,      "[test][mailbox][fault] mailbox invalid open      [passed]" },
-	{ test_fault_mailbox_bad_open,          "[test][mailbox][fault] mailbox bad open          [passed]" },
-	{ test_fault_mailbox_invalid_close,     "[test][mailbox][fault] mailbox invalid close     [passed]" },
-	{ test_fault_mailbox_double_close,      "[test][mailbox][fault] mailbox double close      [passed]" },
-	{ test_fault_mailbox_bad_close,         "[test][mailbox][fault] mailbox bad close         [passed]" },
-	{ test_fault_mailbox_invalid_read,      "[test][mailbox][fault] mailbox invalid read      [passed]" },
-	{ test_fault_mailbox_invalid_read_size, "[test][mailbox][fault] mailbox invalid read size [passed]" },
-	{ test_fault_mailbox_null_read,         "[test][mailbox][fault] mailbox null read         [passed]" },
-	{ test_fault_mailbox_invalid_write,     "[test][mailbox][fault] mailbox invalid write     [passed]" },
-	{ test_fault_mailbox_bad_write,         "[test][mailbox][fault] mailbox bad write         [passed]" },
-	{ test_fault_mailbox_bad_wait,          "[test][mailbox][fault] mailbox bad wait          [passed]" },
-	{ test_fault_mailbox_invalid_ioctl,     "[test][mailbox][fault] mailbox invalid ioctl     [passed]" },
-	{ test_fault_mailbox_bad_ioctl,         "[test][mailbox][fault] mailbox bad ioctl         [passed]" },
-	{ NULL,                                  NULL                                                       },
+	{ test_fault_mailbox_invalid_create,     "[test][mailbox][fault] mailbox invalid create     [passed]" },
+	{ test_fault_mailbox_bad_create,         "[test][mailbox][fault] mailbox bad create         [passed]" },
+	{ test_fault_mailbox_double_create,      "[test][mailbox][fault] mailbox double create      [passed]" },
+	{ test_fault_mailbox_invalid_unlink,     "[test][mailbox][fault] mailbox invalid unlink     [passed]" },
+	{ test_fault_mailbox_double_unlink,      "[test][mailbox][fault] mailbox double unlink      [passed]" },
+	{ test_fault_mailbox_bad_unlink,         "[test][mailbox][fault] mailbox bad unlink         [passed]" },
+	{ test_fault_mailbox_invalid_open,       "[test][mailbox][fault] mailbox invalid open       [passed]" },
+	{ test_fault_mailbox_bad_open,           "[test][mailbox][fault] mailbox bad open           [passed]" },
+	{ test_fault_mailbox_invalid_close,      "[test][mailbox][fault] mailbox invalid close      [passed]" },
+	{ test_fault_mailbox_double_close,       "[test][mailbox][fault] mailbox double close       [passed]" },
+	{ test_fault_mailbox_bad_close,          "[test][mailbox][fault] mailbox bad close          [passed]" },
+	{ test_fault_mailbox_invalid_read,       "[test][mailbox][fault] mailbox invalid read       [passed]" },
+	{ test_fault_mailbox_bad_read,           "[test][mailbox][fault] mailbox bad read           [passed]" },
+	{ test_fault_mailbox_invalid_read_size,  "[test][mailbox][fault] mailbox invalid read size  [passed]" },
+	{ test_fault_mailbox_null_read,          "[test][mailbox][fault] mailbox null read          [passed]" },
+	{ test_fault_mailbox_invalid_write,      "[test][mailbox][fault] mailbox invalid write      [passed]" },
+	{ test_fault_mailbox_bad_write,          "[test][mailbox][fault] mailbox bad write          [passed]" },
+	{ test_fault_mailbox_invalid_write_size, "[test][mailbox][fault] mailbox invalid write size [passed]" },
+	{ test_fault_mailbox_null_write,         "[test][mailbox][fault] mailbox null write         [passed]" },
+	{ test_fault_mailbox_invalid_wait,       "[test][mailbox][fault] mailbox invalid wait       [passed]" },
+	{ test_fault_mailbox_invalid_ioctl,      "[test][mailbox][fault] mailbox invalid ioctl      [passed]" },
+	{ test_fault_mailbox_bad_mbxid,          "[test][mailbox][fault] mailbox bad mbxid          [passed]" },
+	{ NULL,                                   NULL                                                        },
 };
 
 /**
@@ -708,11 +1133,20 @@ static struct test mailbox_tests_fault[] = {
 void test_mailbox(void)
 {
 	int nodenum;
+	int mbx_in;
+	int mbx_out;
+	int remote;
 
 	nodenum = knode_get_num();
 
 	if (nodenum == MASTER_NODENUM || nodenum == SLAVE_NODENUM)
 	{
+		remote = (nodenum == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+		/* Create dummy mailboxes to assure signals reception. */
+		test_assert((mbx_in = kmailbox_create(nodenum, (MAILBOX_PORT_NR - 1))) >= 0);
+		test_assert((mbx_out = kmailbox_open(remote, (MAILBOX_PORT_NR - 1))) >= 0);
+
 		/* API Tests */
 		if (nodenum == MASTER_NODENUM)
 			nanvix_puts("--------------------------------------------------------------------------------");
@@ -734,6 +1168,10 @@ void test_mailbox(void)
 			if (nodenum == MASTER_NODENUM)
 				nanvix_puts(mailbox_tests_fault[i].name);
 		}
+
+		/* Destroy dummy mailboxes. */
+		test_assert(kmailbox_unlink(mbx_in) == 0);
+		test_assert(kmailbox_close(mbx_out) == 0);
 	}
 }
 


### PR DESCRIPTION
# Description #
In this PR the regression tests were updated to get inline with the new Mailbox Interface that supports messages multiplexing on the kernel. Also, the tests set were enhanced to evaluate a greater range of behaviors.

#### Renamed tests ####
- `test_api_mailbox_multiple_create_open` -> `test_api_mailbox_virtualization`
- `test_api_mailbox_multiplex` -> `test_api_mailbox_multiplexation`
- `test_fault_mailbox_bad_ioctl` -> `test_fault_mailbox_bad_mbxid`

#### New API tests ####
- **`test_api_mailbox_multiplexation_2`**: to test out of order reception;
- **`test_api_mailbox_multiplexation_3`**: to test multiplexed messages storage;
- **`test_api_mailbox_pending_msg_unlink`**: to assert that the kernel avoids `mailbox_unlink` calls on ports that have pending messages;

#### New fault tests ####
- `test_fault_mailbox_double_create`
- `test_fault_mailbox_bad_unlink`
- `test_fault_mailbox_bad_read`
- `test_fault_mailbox_invalid_write_size`
- `test_fault_mailbox_null_write`
- `test_fault_mailbox_invalid_wait`
- `test_fault_mailbox_bad_mbxid`
