### PR TITLE
[tests] Messages Forwarding Tests

### DIFF
--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -67,10 +67,6 @@ int kportal_allow(int portalid, int remote, int remote_port)
 {
 	int ret;
 
-	/* Invalid remote number for the requesting core ID. */
-	if (remote == knode_get_num())
-		return (-EINVAL);
-
 	ret = kcall3(
 		NR_portal_allow,
 		(word_t) portalid,
@@ -92,16 +88,9 @@ int kportal_allow(int portalid, int remote, int remote_port)
 int kportal_open(int local, int remote, int remote_port)
 {
 	int ret;
-	int nodenum;
-
-	nodenum = knode_get_num();
 
 	/* Invalid local number for the requesting core ID. */
-	if (local != nodenum)
-		return (-EINVAL);
-
-	/* Invalid remote number for the requesting core ID. */
-	if (remote == nodenum)
+	if (local != knode_get_num())
 		return (-EINVAL);
 
 	ret = kcall3(


### PR DESCRIPTION
# Description #
In this PR, we added more API tests to evaluate the messages forwarding implementation in the kernel. It were added tests for Mailbox and Portal, namely:
- `test_api_mailbox_msg_forwarding`
- `test_api_portal_msg_forwarding`

Also, small corrections were made on the existing ones to remove faulting tests on behaviors that are allowed.