### PR TITLE
Enhancement remove nodenum exchange

### DIFF
--- a/include/nanvix/sys/noc.h
+++ b/include/nanvix/sys/noc.h
@@ -37,7 +37,6 @@
 	 */
 	/**@{*/
 	extern int knode_get_num(void);
-	extern int knode_set_num(int nodenum);
 	/**@}*/
 
 #endif /* NANVIX_SYS_NOC_H_ */

--- a/src/libnanvix/ikc/noc.c
+++ b/src/libnanvix/ikc/noc.c
@@ -35,50 +35,10 @@
 int knode_get_num(void)
 {
 	int ret;
-    int coreid;
 
-    coreid = core_get_id();
-
-	ret = kcall1(
-		NR_node_get_num,
-		(word_t) coreid
+	ret = kcall0(
+		NR_node_get_num
 	);
 
 	return (ret);
-}
-
-/*============================================================================*
- * knode_set_num()                                                            *
- *============================================================================*/
-
-/*
- * @see kernel_node_set_num()
- */
-int knode_set_num(int nodenum)
-{
-#if (PROCESSOR_HAS_NOC)
-
-	int ret;
-    int coreid;
-
-    if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
-        return (-EINVAL);
-
-    coreid = core_get_id();
-
-	ret = kcall2(
-		NR_node_set_num,
-		(word_t) coreid,
-		(word_t) nodenum
-	);
-
-	return (ret);
-
-#else
-
-	UNUSED(nodenum);
-
-	return (-ENOSYS);
-
-#endif
 }

--- a/src/libnanvix/ikc/sync.c
+++ b/src/libnanvix/ikc/sync.c
@@ -55,7 +55,7 @@ int ksync_create(const int *nodes, int nnodes, int type)
 		return (-EINVAL);
 
 	/* Gets the local node number. */
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = processor_node_get_num();
 
 	ret = kcall4(
 		NR_sync_create,
@@ -94,7 +94,7 @@ int ksync_open(const int *nodes, int nnodes, int type)
 		return (-EINVAL);
 
 	/* Gets the local node number. */
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = processor_node_get_num();
 
 	ret = kcall4(
 		NR_sync_open,

--- a/src/test/knoc.c
+++ b/src/test/knoc.c
@@ -54,91 +54,6 @@ PRIVATE void test_node_get_num(void)
 	KASSERT(nodenum == 0);
 }
 
-/*----------------------------------------------------------------------------*
- * Exchange Logical NoC Node Number                                           *
- *----------------------------------------------------------------------------*/
-
-#if (PROCESSOR_HAS_NOC)
-
-/**
- * @brief API Test: Exchange Logical NoC Node Number
- */
-PRIVATE void test_node_set_num(void)
-{
-	int nodenum;
-
-	nodenum = knode_get_num();
-	KASSERT(nodenum == 0);
-
-#if (TEST_NOC_VERBOSE)
-    kprintf("[test][processor][node][api] noc node %d online", nodenum);
-#endif
-
-        /* New nodenum (1 % (Interfaces available in only one IO Cluster)) */
-        nodenum += (1 % (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM));
-
-        #if (TEST_NOC_VERBOSE)
-            kprintf("[test][processor][node][api] exchange noc node number to %d", nodenum);
-        #endif
-
-        KASSERT(knode_set_num(nodenum) == 0);
-        KASSERT(knode_get_num() == nodenum);
-
-        /* Restoure old nodenum. */
-        nodenum -= (1 % (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM));
-
-        KASSERT(knode_set_num(nodenum) == 0);
-
-	nodenum = knode_get_num();
-	KASSERT(nodenum == 0);
-}
-
-#endif
-
-/*============================================================================*
- * Fault Tests                                                                *
- *============================================================================*/
-
-/*----------------------------------------------------------------------------*
- * Exchange Logical NoC Node Number with invalid arguments                    *
- *----------------------------------------------------------------------------*/
-
-#if (PROCESSOR_HAS_NOC)
-
-/**
- * @brief FAULT Test: Invalid Set Logical NoC Node Number
- */
-PRIVATE void test_node_invalid_set_num(void)
-{
-	/* Invalid nodenum. */
-	KASSERT(knode_set_num(-1) == -EINVAL);
-	KASSERT(knode_set_num(PROCESSOR_NOC_NODES_NUM) == -EINVAL);
-}
-
-#endif
-
-/*----------------------------------------------------------------------------*
- * Exchange Logical NoC Node Number with bad arguments                        *
- *----------------------------------------------------------------------------*/
-
-#if (PROCESSOR_HAS_NOC)
-
-/**
- * @brief FAULT Test: Bad Set Logical NoC Node Number
- */
-PRIVATE void test_node_bad_set_num(void)
-{
-	int nodenum;
-
-	/* nodenum + (Interfaces available in only one IO Cluster). */
-	nodenum = 0 + (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM);
-
-	/* Bad nodenum. */
-	KASSERT(knode_set_num(nodenum) == -EINVAL);
-}
-
-#endif
-
 /*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
@@ -148,21 +63,7 @@ PRIVATE void test_node_bad_set_num(void)
  */
 PRIVATE struct test test_api_noc[] = {
 	{ test_node_get_num,  "[test][processor][node][api] get logical noc node num [passed]" },
-#if (PROCESSOR_HAS_NOC)
-	{ test_node_set_num,  "[test][processor][node][api] set logical noc node num [passed]" },
-#endif
 	{ NULL,                NULL                                                            },
-};
-
-/**
- * @brief FAULT Tests.
- */
-PRIVATE struct test test_fault_noc[] = {
-#if (PROCESSOR_HAS_NOC)
-	{ test_node_invalid_set_num, "[test][processor][node][fault] invalid set logical noc node num [passed]" },
-	{ test_node_bad_set_num,     "[test][processor][node][fault] bad set logical noc node num     [passed]" },
-#endif
-	{ NULL,                       NULL                                                                      },
 };
 
 /**
@@ -180,13 +81,5 @@ PUBLIC void test_noc(void)
 	{
 		test_api_noc[i].test_fn();
         nanvix_puts(test_api_noc[i].name);
-	}
-
-	/* FAULT Tests */
-	nanvix_puts("--------------------------------------------------------------------------------");
-	for (int i = 0; test_fault_noc[i].test_fn != NULL; i++)
-	{
-		test_fault_noc[i].test_fn();
-        nanvix_puts(test_fault_noc[i].name);
 	}
 }


### PR DESCRIPTION
In this PR, I remove the dependency of the coreid to get the local `nodenum`. Also, I remove the unnecessary `knode_set_num` and its redundant code.