### PR TITLE
[ikc] IKC Functions Repetition Control

### DIFF
--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -134,7 +134,7 @@ ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
 			(word_t) buffer,
 			(word_t) KMAILBOX_MESSAGE_SIZE
 		);
-	} while (ret == -EBUSY);
+	} while ((ret == -EBUSY));
 
 	return (ret);
 }
@@ -246,6 +246,7 @@ ssize_t kmailbox_read(int mbxid, void *buffer, size_t size)
 	/* Repeat while reading valid messages for another ports. */
 	do
 	{
+		/* Read a message. */
 		if ((ret = kmailbox_aread(mbxid, buffer2, KMAILBOX_MESSAGE_SIZE)) < 0)
 			return (ret);
 	} while ((ret = kmailbox_wait(mbxid)) > 0);

--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -170,7 +170,7 @@ int kportal_aread(int portalid, void * buffer, size_t size)
 			(word_t) portalid,
 			(word_t) buffer,
 			(word_t) size);
-	} while (ret == -EBUSY);
+	} while ((ret == -EBUSY) || (ret == -ENOMSG));
 
 	return (ret);
 }
@@ -279,6 +279,7 @@ ssize_t kportal_read(int portalid, void *buffer, size_t size)
 	/* Repeat while reading valid messages for another ports. */
 	do
 	{
+		/* Read a message. */
 		if ((ret = kportal_aread(portalid, buffer, size)) < 0)
 			return (ret);
 	} while ((ret = kportal_wait(portalid)) > 0);

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -1015,7 +1015,7 @@ static void test_fault_portal_double_allow(void)
 
 	test_assert((portalid = kportal_create(local, 0)) >= 0);
 	test_assert(kportal_allow(portalid, remote, 0) == 0);
-	test_assert(kportal_allow(portalid, remote, 0) == -EBUSY);
+	test_assert(kportal_allow(portalid, remote, 0) == -EBADF);
 	test_assert(kportal_unlink(portalid) == 0);
 }
 


### PR DESCRIPTION
# Description #
This PR is a small adjustment to the IKC functions (Read/Write) of Portals and Mailboxes, to adequate the retry control of these functions with the possible return values of the Microkernel functions.