### PR TITLE
[ikc] Mailbox Non-blocking Read

### DIFF
--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -163,7 +163,7 @@ ssize_t kmailbox_aread(int mbxid, void *buffer, size_t size)
 			(word_t) buffer,
 			(word_t) KMAILBOX_MESSAGE_SIZE
 		);
-	} while ((ret == -ETIMEDOUT) || (ret == -EBUSY));
+	} while ((ret == -ETIMEDOUT) || (ret == -EBUSY) || (ret == -ENOMSG));
 
 	return (ret);
 }


### PR DESCRIPTION
## Description
In this PR, we retry a read when it returns `ENOMSG` error.