### PR TITLE
[ikc] New Communicator Get_Port Kcall

### DIFF
--- a/include/nanvix/sys/noc.h
+++ b/include/nanvix/sys/noc.h
@@ -38,6 +38,7 @@
 	/**@{*/
 	extern int knode_get_num(void);
 	extern int kcluster_get_num(void);
+	extern int kcomm_get_port(int, int);
 	/**@}*/
 
 #endif /* NANVIX_SYS_NOC_H_ */

--- a/src/libnanvix/ikc/noc.c
+++ b/src/libnanvix/ikc/noc.c
@@ -60,3 +60,29 @@ int kcluster_get_num(void)
 
 	return (ret);
 }
+
+/*============================================================================*
+ * kcomm_get_port()                                                           *
+ *============================================================================*/
+
+/*
+ * @see kernel_comm_get_num()
+ */
+int kcomm_get_port(int id, int type)
+{
+	int ret;
+
+	if (id < 0)
+		return (-EINVAL);
+
+	if ((type != COMM_TYPE_MAILBOX) && (type != COMM_TYPE_PORTAL))
+		return (-EINVAL);
+
+	ret = kcall2(
+		NR_comm_get_port,
+		(word_t) id,
+		(word_t) type
+	);
+
+	return (ret);
+}

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -537,7 +537,7 @@ static void test_api_portal_multiplexation_3(void)
 
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_PORTAL_SELECT_NR; ++i)
 		{
-			port = portal_in[i] % KPORTAL_PORT_NR;
+			port = kcomm_get_port(portal_in[i], COMM_TYPE_PORTAL);
 
 			kmemset(message, -1, MESSAGE_SIZE);
 


### PR DESCRIPTION
# Description #
This PR defines the support to the `communicator_get_port` kernel call, attending the necessity of knowing which port a `portal_open` call allocated.