### PR TITLE
[tests] IKC Common Constants

### DIFF
--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -33,38 +33,9 @@
 
 #if __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL
 
-/**
- * @brief Test's parameters
- */
-#define NR_NODES       2
-#define NR_NODES_MAX   PROCESSOR_NOC_NODES_NUM
-#define MESSAGE_SIZE   1024
-#define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-#else
-	#define SLAVE_NODENUM  1
-#endif
-
 /*============================================================================*
  * Stress Tests                                                               *
  *============================================================================*/
-
-/**
- * @name Number of setups and communications.
- */
-/**@{*/
-#define NSETUPS 1
-#define NCOMMUNICATIONS 1
-#define TEST_MAILBOX_SIZE KMAILBOX_MESSAGE_SIZE
-#define PORTAL_SIZE 512
-#define MAILBOX_SIZE KMAILBOX_MESSAGE_SIZE
-#ifdef __mppa256__
-	#define TEST_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_NPORTS (THREAD_MAX)
-#endif
-/**@}*/
 
 /*============================================================================*
  * Stress Test: Portal Create Unlink                                          *
@@ -402,8 +373,8 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_NPORTS];
-	int portalids[TEST_NPORTS];
+	int mbxids[TEST_THREAD_NPORTS];
+	int portalids[TEST_THREAD_NPORTS];
 	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
@@ -415,20 +386,20 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
 					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_close(portalids[j]) == 0);
 				test_assert(kmailbox_close(mbxids[j]) == 0);
@@ -439,7 +410,7 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
@@ -447,7 +418,7 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -460,7 +431,7 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_unlink(portalids[j]) == 0);
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
@@ -480,8 +451,8 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_NPORTS];
-	int portalids[TEST_NPORTS];
+	int mbxids[TEST_THREAD_NPORTS];
+	int portalids[TEST_THREAD_NPORTS];
 	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
@@ -493,20 +464,20 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
 					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_close(portalids[j]) == 0);
 				test_assert(kmailbox_close(mbxids[j]) == 0);
@@ -517,7 +488,7 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
@@ -525,7 +496,7 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -538,7 +509,7 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_unlink(portalids[j]) == 0);
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
@@ -558,10 +529,10 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 {
 	int local;
 	int remote;
-	int inboxes[TEST_NPORTS];
-	int outboxes[TEST_NPORTS];
-	int inportals[TEST_NPORTS];
-	int outportals[TEST_NPORTS];
+	int inboxes[TEST_THREAD_NPORTS];
+	int outboxes[TEST_THREAD_NPORTS];
+	int inportals[TEST_THREAD_NPORTS];
+	int outportals[TEST_THREAD_NPORTS];
 	char msg_in[PORTAL_SIZE];
 	char msg_out[PORTAL_SIZE];
 
@@ -572,7 +543,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert((inboxes[j] = kmailbox_create(local, j)) >= 0);
 			test_assert((outboxes[j] = kmailbox_open(remote, j)) >= 0);
@@ -584,7 +555,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kmailbox_read(inboxes[k], msg_in, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -605,7 +576,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(outboxes[k], msg_out, MAILBOX_SIZE) == MAILBOX_SIZE);
 
@@ -623,7 +594,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 			}
 		}
 
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert(kportal_close(outportals[j]) == 0);
 			test_assert(kportal_unlink(inportals[j]) == 0);
@@ -644,10 +615,10 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 {
 	int local;
 	int remote;
-	int inboxes[TEST_NPORTS];
-	int outboxes[TEST_NPORTS];
-	int inportals[TEST_NPORTS];
-	int outportals[TEST_NPORTS];
+	int inboxes[TEST_THREAD_NPORTS];
+	int outboxes[TEST_THREAD_NPORTS];
+	int inportals[TEST_THREAD_NPORTS];
+	int outportals[TEST_THREAD_NPORTS];
 	char msg_in[PORTAL_SIZE];
 	char msg_out[PORTAL_SIZE];
 
@@ -658,7 +629,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert((inboxes[j] = kmailbox_create(local, j)) >= 0);
 			test_assert((outboxes[j] = kmailbox_open(remote, j)) >= 0);
@@ -670,7 +641,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kmailbox_read(inboxes[k], msg_in, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -691,7 +662,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(outboxes[k], msg_out, MAILBOX_SIZE) == MAILBOX_SIZE);
 
@@ -709,7 +680,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 			}
 		}
 
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert(kportal_close(outportals[j]) == 0);
 			test_assert(kportal_unlink(inportals[j]) == 0);
@@ -782,12 +753,6 @@ PRIVATE void fence(struct fence *b)
 		spinlock_unlock(&b->lock);
 	}
 }
-
-#ifdef __mppa256__
-	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_THREAD_NPORTS (THREAD_MAX)
-#endif
 
 /*============================================================================*
  * Stress Test: Portal Thread Multiplexing Broadcast                          *

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -32,18 +32,6 @@
 
 #if __TARGET_HAS_MAILBOX
 
-/**
- * @brief Test's parameters
- */
-#define NR_NODES       2
-#define NR_NODES_MAX   PROCESSOR_NOC_NODES_NUM
-#define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-#else
-	#define SLAVE_NODENUM  1
-#endif
-
 /*============================================================================*
  * API Test: Create Unlink                                                    *
  *============================================================================*/
@@ -1093,15 +1081,6 @@ static void test_fault_mailbox_bad_mbxid(void)
  * Stress Tests                                                               *
  *============================================================================*/
 
-/**
- * @name Number of setups and communications.
- */
-/**@{*/
-#define NSETUPS 1
-#define NCOMMUNICATIONS 1
-#define TEST_MAILBOX_NPORTS TEST_MULTIPLEXATION_MBX_PAIRS
-/**@}*/
-
 /*============================================================================*
  * Stress Test: Mailbox Create Unlink                                         *
  *============================================================================*/
@@ -1307,7 +1286,7 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_MAILBOX_NPORTS];
+	int mbxids[TEST_MULTIPLEXATION_MBX_PAIRS];
 	char message[KMAILBOX_MESSAGE_SIZE];
 
 	local = knode_get_num();
@@ -1319,14 +1298,14 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 		}
 	}
@@ -1334,12 +1313,12 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
@@ -1347,7 +1326,7 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 		}
 	}
@@ -1364,7 +1343,7 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_MAILBOX_NPORTS];
+	int mbxids[TEST_MULTIPLEXATION_MBX_PAIRS];
 	char message[KMAILBOX_MESSAGE_SIZE];
 
 	local = knode_get_num();
@@ -1376,14 +1355,14 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 		}
 	}
@@ -1391,12 +1370,12 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
@@ -1404,7 +1383,7 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 		}
 	}
@@ -1421,8 +1400,8 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 {
 	int local;
 	int remote;
-	int inboxes[TEST_MAILBOX_NPORTS];
-	int outboxes[TEST_MAILBOX_NPORTS];
+	int inboxes[TEST_MULTIPLEXATION_MBX_PAIRS];
+	int outboxes[TEST_MULTIPLEXATION_MBX_PAIRS];
 	char msg_in[KMAILBOX_MESSAGE_SIZE];
 	char msg_out[KMAILBOX_MESSAGE_SIZE];
 
@@ -1433,7 +1412,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert((inboxes[j] = kmailbox_create(local, j)) >= 0);
 			test_assert((outboxes[j] = kmailbox_open(remote, j)) >= 0);
@@ -1443,7 +1422,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kmailbox_read(inboxes[k], msg_in, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
@@ -1457,7 +1436,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(outboxes[k], msg_out, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
@@ -1468,7 +1447,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 			}
 		}
 
-		for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert(kmailbox_close(outboxes[j]) == 0);
 			test_assert(kmailbox_unlink(inboxes[j]) == 0);
@@ -1539,12 +1518,6 @@ PRIVATE void fence(struct fence *b)
 		spinlock_unlock(&b->lock);
 	}
 }
-
-#ifdef __mppa256__
-	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_THREAD_NPORTS (THREAD_MAX)
-#endif
 
 /*============================================================================*
  * Stress Test: Mailbox Thread Multiplexing Broadcast                         *

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -31,19 +31,6 @@
 
 #if __TARGET_HAS_PORTAL
 
-/**
- * @brief Test's parameters
- */
-#define NR_NODES       2
-#define NR_NODES_MAX   PROCESSOR_NOC_NODES_NUM
-#define MESSAGE_SIZE   1024
-#define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-#else
-	#define SLAVE_NODENUM  1
-#endif
-
 /*============================================================================*
  * API Test: Create Unlink                                                    *
  *============================================================================*/
@@ -165,7 +152,7 @@ static void test_api_portal_read_write(void)
 	int portal_out;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -187,44 +174,44 @@ static void test_api_portal_read_write(void)
 	{
 		for (unsigned i = 0; i < NITERATIONS; i++)
 		{
-			kmemset(message, 0, MESSAGE_SIZE);
+			kmemset(message, 0, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in, remote, 0) == 0);
-			test_assert(kportal_read(portal_in, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert(message[j] == 1);
 
-			kmemset(message, 2, MESSAGE_SIZE);
+			kmemset(message, 2, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out, message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 	}
 	else
 	{
 		for (unsigned i = 0; i < NITERATIONS; i++)
 		{
-			kmemset(message, 1, MESSAGE_SIZE);
+			kmemset(message, 1, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			kmemset(message, 0, MESSAGE_SIZE);
+			kmemset(message, 0, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in, remote, 0) == 0);
-			test_assert(kportal_read(portal_in, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert(message[j] == 2);
 		}
 	}
 
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
@@ -286,7 +273,7 @@ static void test_api_portal_multiplexation(void)
 	int portal_out[TEST_MULTIPLEXATION_PORTAL_PAIRS];
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -303,33 +290,33 @@ static void test_api_portal_multiplexation(void)
 	{
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++i)
 		{
-			kmemset(message, (i - 1), MESSAGE_SIZE);
+			kmemset(message, (i - 1), PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, i) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - i) == 0);
 
-			kmemset(message, (i + 1), MESSAGE_SIZE);
+			kmemset(message, (i + 1), PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 	}
 	else
 	{
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, i) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - i - 1) == 0);
 		}
 	}
@@ -338,12 +325,12 @@ static void test_api_portal_multiplexation(void)
 	for (unsigned i = 0; i < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++i)
 	{
 		test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 		test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 
 		test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 		test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 
@@ -366,7 +353,7 @@ static void test_api_portal_allow(void)
 	int remote;
 	int portal_in[2];
 	int portal_out[2];
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -378,7 +365,7 @@ static void test_api_portal_allow(void)
 
 		for (unsigned i = 0; i < 2; ++i)
 		{
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_close(portal_out[i]) == 0);
 		}
@@ -391,12 +378,12 @@ static void test_api_portal_allow(void)
 
 		/* Allowing tests. */
 		test_assert(kportal_allow(portal_in[0], remote, 0) == 0);
-		test_assert(kportal_read(portal_in[1], message, MESSAGE_SIZE) == -EACCES);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == MESSAGE_SIZE);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == -EACCES);
+		test_assert(kportal_read(portal_in[1], message, PORTAL_SIZE) == -EACCES);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == PORTAL_SIZE);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == -EACCES);
 		test_assert(kportal_allow(portal_in[1], remote, 1) == 0);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == -EACCES);
-		test_assert(kportal_read(portal_in[1], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == -EACCES);
+		test_assert(kportal_read(portal_in[1], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		/* Unlinks the created vportals. */
 		for (unsigned i = 0; i < 2; ++i)
@@ -422,7 +409,7 @@ static void test_api_portal_multiplexation_2(void)
 	int portal_out[TEST_MULTIPLEXATION2_PORTAL_PAIRS];
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -439,17 +426,17 @@ static void test_api_portal_multiplexation_2(void)
 		/* Read the messages in descendant order. */
 		for (int i = (TEST_MULTIPLEXATION2_PORTAL_PAIRS - 1); i >= 0; --i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, i) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - i) == 0);
 
 			/* Checks the data transfered by each vportal. */
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 		}
@@ -458,12 +445,12 @@ static void test_api_portal_multiplexation_2(void)
 	{
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_PORTAL_PAIRS; ++i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 		}
@@ -501,7 +488,7 @@ static void test_api_portal_multiplexation_3(void)
 	int port;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -515,16 +502,16 @@ static void test_api_portal_multiplexation_3(void)
 		/* Sends all the messages to the SLAVE node. */
 		for (int i = (TEST_MULTIPLEXATION3_PORTAL_MSGS_NR - 1); i >= 0; --i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 
 		/* Closes the opened vportals. */
 		for (unsigned int i = 0; i < TEST_MULTIPLEXATION3_PORTAL_MSGS_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 
 			test_assert(kportal_close(portal_out[i]) == 0);
 		}
@@ -539,12 +526,12 @@ static void test_api_portal_multiplexation_3(void)
 		{
 			port = kcomm_get_port(portal_in[i], COMM_TYPE_PORTAL);
 
-			kmemset(message, -1, MESSAGE_SIZE);
+			kmemset(message, -1, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, port) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - port) == 0);
 		}
 
@@ -552,7 +539,7 @@ static void test_api_portal_multiplexation_3(void)
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_PORTAL_SELECT_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 
@@ -588,7 +575,7 @@ static void test_api_portal_multiplexation_4(void)
 	int port;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -607,13 +594,13 @@ static void test_api_portal_multiplexation_4(void)
 			{
 				port = (i*2 + j);
 
-				kmemset(message, -1, MESSAGE_SIZE);
+				kmemset(message, -1, PORTAL_SIZE);
 
 				test_assert(kportal_allow(portal_in[i], remote, port) == 0);
-				test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+				test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				/* Asserts the message data. */
-				for (unsigned k = 0; k < MESSAGE_SIZE; ++k)
+				for (unsigned k = 0; k < PORTAL_SIZE; ++k)
 					test_assert((message[k] - port) == 0);
 			}
 		}
@@ -622,7 +609,7 @@ static void test_api_portal_multiplexation_4(void)
 		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SELECT_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == (MESSAGE_SIZE * TEST_MLTPX4_PORTAL_SELECT_MSG));
+			test_assert(volume == (PORTAL_SIZE * TEST_MLTPX4_PORTAL_SELECT_MSG));
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 
@@ -639,16 +626,16 @@ static void test_api_portal_multiplexation_4(void)
 		/* Sends all the messages to the MASTER node. */
 		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SEND_NR; ++i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 
 		/* Checks the data volume transferred by each vportal. */
 		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SEND_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 
 			/* Closes the output vportals. */
 			test_assert(kportal_close(portal_out[i]) == 0);
@@ -677,7 +664,7 @@ static void test_api_portal_pending_msg_unlink(void)
 	uint64_t latency;
 	int portal_in[TEST_PENDING_UNLINK_PORTAL_PAIRS];
 	int portal_out[TEST_PENDING_UNLINK_PORTAL_PAIRS];
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -689,13 +676,13 @@ static void test_api_portal_pending_msg_unlink(void)
 			test_assert((portal_out[i] = kportal_open(local, remote, i)) >= 0);
 
 		for (int i = 0; i < TEST_PENDING_UNLINK_PORTAL_PAIRS; ++i)
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		/* Checks the data volume transfered by each vportal. */
 		for (unsigned i = 0; i < TEST_PENDING_UNLINK_PORTAL_PAIRS; ++i)
 		{
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 
@@ -711,10 +698,10 @@ static void test_api_portal_pending_msg_unlink(void)
 
 		/* Unlink tests. */
 		test_assert(kportal_allow(portal_in[1], remote, 1) == 0);
-		test_assert(kportal_read(portal_in[1], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in[1], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		test_assert(kportal_ioctl(portal_in[1], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 
 		test_assert(kportal_unlink(portal_in[1]) == 0);
 
@@ -722,10 +709,10 @@ static void test_api_portal_pending_msg_unlink(void)
 		test_assert(kportal_unlink(portal_in[0]) == -EBUSY);
 
 		test_assert(kportal_allow(portal_in[0], remote, 0) == 0);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		test_assert(kportal_ioctl(portal_in[0], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 
 		test_assert(kportal_unlink(portal_in[0]) == 0);
 	}
@@ -745,7 +732,7 @@ static void test_api_portal_msg_forwarding(void)
 	int portal_out;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 
@@ -766,25 +753,25 @@ static void test_api_portal_msg_forwarding(void)
 	{
 		test_assert(kportal_allow(portal_in, local, 0) == 0);
 
-		kmemset(message, local, MESSAGE_SIZE);
+		kmemset(message, local, PORTAL_SIZE);
 
-		test_assert(kportal_write(portal_out, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_write(portal_out, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-		kmemset(message, -1, MESSAGE_SIZE);
+		kmemset(message, -1, PORTAL_SIZE);
 
-		test_assert(kportal_read(portal_in, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-		for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+		for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 			test_assert(message[j] == local);
 	}
 
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
@@ -1049,10 +1036,10 @@ static void test_fault_portal_bad_allow(void)
  */
 static void test_fault_portal_invalid_read(void)
 {
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
-	test_assert(kportal_read(-1, buffer, MESSAGE_SIZE) == -EINVAL);
-	test_assert(kportal_read(KPORTAL_MAX, buffer, MESSAGE_SIZE) == -EINVAL);
+	test_assert(kportal_read(-1, buffer, PORTAL_SIZE) == -EINVAL);
+	test_assert(kportal_read(KPORTAL_MAX, buffer, PORTAL_SIZE) == -EINVAL);
 }
 
 /*============================================================================*
@@ -1067,14 +1054,14 @@ static void test_fault_portal_bad_read(void)
 	int local;
 	int remote;
 	int portalid;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
 	test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
-	test_assert(kportal_read(portalid, buffer, MESSAGE_SIZE) == -EBADF);
+	test_assert(kportal_read(portalid, buffer, PORTAL_SIZE) == -EBADF);
 
 	test_assert(kportal_close(portalid) == 0);
 }
@@ -1090,7 +1077,7 @@ static void test_fault_portal_invalid_read_size(void)
 {
 	int portalid;
 	int local;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 
@@ -1119,7 +1106,7 @@ static void test_fault_portal_null_read(void)
 
 	test_assert((portalid = kportal_create(local, 0)) >= 0);
 
-		test_assert(kportal_read(portalid, NULL, MESSAGE_SIZE) == -EINVAL);
+		test_assert(kportal_read(portalid, NULL, PORTAL_SIZE) == -EINVAL);
 
 	test_assert(kportal_unlink(portalid) == 0);
 }
@@ -1133,10 +1120,10 @@ static void test_fault_portal_null_read(void)
  */
 static void test_fault_portal_invalid_write(void)
 {
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
-	test_assert(kportal_write(-1, buffer, MESSAGE_SIZE) == -EINVAL);
-	test_assert(kportal_write(KPORTAL_MAX, buffer, MESSAGE_SIZE) == -EINVAL);
+	test_assert(kportal_write(-1, buffer, PORTAL_SIZE) == -EINVAL);
+	test_assert(kportal_write(KPORTAL_MAX, buffer, PORTAL_SIZE) == -EINVAL);
 }
 
 /*============================================================================*
@@ -1150,13 +1137,13 @@ static void test_fault_portal_bad_write(void)
 {
 	int local;
 	int portalid;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 
 	test_assert((portalid = kportal_create(local, 0)) >= 0);
 
-		test_assert(kportal_write(portalid, buffer, MESSAGE_SIZE) == -EBADF);
+		test_assert(kportal_write(portalid, buffer, PORTAL_SIZE) == -EBADF);
 
 	test_assert(kportal_unlink(portalid) == 0);
 }
@@ -1173,7 +1160,7 @@ static void test_fault_portal_invalid_write_size(void)
 	int local;
 	int remote;
 	int portalid;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1205,7 +1192,7 @@ static void test_fault_portal_null_write(void)
 
 	test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
-		test_assert(kportal_write(portalid, NULL, MESSAGE_SIZE) == -EINVAL);
+		test_assert(kportal_write(portalid, NULL, PORTAL_SIZE) == -EINVAL);
 
 	test_assert(kportal_close(portalid) == 0);
 }
@@ -1264,7 +1251,7 @@ static void test_fault_portal_bad_portalid(void)
 	int remote;
 	int local;
 	size_t volume;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1274,8 +1261,8 @@ static void test_fault_portal_bad_portalid(void)
 	test_assert(kportal_close(portal) == -EBADF);
 	test_assert(kportal_unlink(portal) == -EBADF);
 	test_assert(kportal_allow(portal, remote, 0) == -EBADF)
-	test_assert(kportal_read(portal, buffer, MESSAGE_SIZE) == -EBADF);
-	test_assert(kportal_write(portal, buffer, MESSAGE_SIZE) == -EBADF);
+	test_assert(kportal_read(portal, buffer, PORTAL_SIZE) == -EBADF);
+	test_assert(kportal_write(portal, buffer, PORTAL_SIZE) == -EBADF);
 	test_assert(kportal_wait(portal) == -EBADF);
 	test_assert(kportal_ioctl(portal, KPORTAL_IOCTL_GET_VOLUME, &volume) == -EBADF);
 }
@@ -1283,16 +1270,6 @@ static void test_fault_portal_bad_portalid(void)
 /*============================================================================*
  * Stress Tests                                                               *
  *============================================================================*/
-
-/**
- * @name Number of setups and communications.
- */
-/**@{*/
-#define NSETUPS 1
-#define NCOMMUNICATIONS 1
-#define TEST_PORTAL_SIZE 512
-#define TEST_PORTAL_NPORTS TEST_MULTIPLEXATION_PORTAL_PAIRS
-/**@}*/
 
 /*============================================================================*
  * Stress Test: Portal Create Unlink                                          *
@@ -1350,7 +1327,7 @@ PRIVATE void test_stress_portal_broadcast(void)
 	int local;
 	int remote;
 	int portalid;
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 	
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1364,7 +1341,7 @@ PRIVATE void test_stress_portal_broadcast(void)
 			test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				test_assert(kportal_write(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_close(portalid) == 0);
 		}
@@ -1379,7 +1356,7 @@ PRIVATE void test_stress_portal_broadcast(void)
 			{
 				message[0] = local;
 				test_assert(kportal_allow(portalid, remote, 0) >= 0);
-				test_assert(kportal_read(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(message[0] == remote);
 			}
 
@@ -1400,7 +1377,7 @@ PRIVATE void test_stress_portal_gather(void)
 	int local;
 	int remote;
 	int portalid;
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1414,7 +1391,7 @@ PRIVATE void test_stress_portal_gather(void)
 			test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				test_assert(kportal_write(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_close(portalid) == 0);
 		}
@@ -1429,7 +1406,7 @@ PRIVATE void test_stress_portal_gather(void)
 			{
 				message[0] = local;
 				test_assert(kportal_allow(portalid, remote, 0) >= 0);
-				test_assert(kportal_read(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(message[0] == remote);
 			}
 
@@ -1451,8 +1428,8 @@ PRIVATE void test_stress_portal_pingpong(void)
 	int remote;
 	int inportal;
 	int outportal;
-	char msg_in[TEST_PORTAL_SIZE];
-	char msg_out[TEST_PORTAL_SIZE];
+	char msg_in[PORTAL_SIZE];
+	char msg_out[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1470,21 +1447,21 @@ PRIVATE void test_stress_portal_pingpong(void)
 			{
 				msg_in[0] = local;
 				test_assert(kportal_allow(inportal, remote, 0) >= 0);
-				test_assert(kportal_read(inportal, msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(inportal, msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(msg_in[0] == remote);
 
-				test_assert(kportal_write(outportal, msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(outportal, msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 			}
 		}
 		else
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				test_assert(kportal_write(outportal, msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(outportal, msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 
 				msg_in[0] = local;
 				test_assert(kportal_allow(inportal, remote, 0) >= 0);
-				test_assert(kportal_read(inportal, msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(inportal, msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(msg_in[0] == remote);
 			}
 		}
@@ -1505,8 +1482,8 @@ PRIVATE void test_stress_portal_multiplexing_broadcast(void)
 {
 	int local;
 	int remote;
-	int portalids[TEST_PORTAL_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	int portalids[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1517,14 +1494,14 @@ PRIVATE void test_stress_portal_multiplexing_broadcast(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_close(portalids[j]) == 0);
 		}
 	}
@@ -1532,21 +1509,21 @@ PRIVATE void test_stress_portal_multiplexing_broadcast(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, k) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 				}
 			}
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 		}
 	}
@@ -1563,8 +1540,8 @@ PRIVATE void test_stress_portal_multiplexing_gather(void)
 {
 	int local;
 	int remote;
-	int portalids[TEST_PORTAL_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	int portalids[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1575,14 +1552,14 @@ PRIVATE void test_stress_portal_multiplexing_gather(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_close(portalids[j]) == 0);
 		}
 	}
@@ -1590,21 +1567,21 @@ PRIVATE void test_stress_portal_multiplexing_gather(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, k) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 				}
 			}
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 		}
 	}
@@ -1621,10 +1598,10 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 {
 	int local;
 	int remote;
-	int inportals[TEST_PORTAL_NPORTS];
-	int outportals[TEST_PORTAL_NPORTS];
-	PRIVATE char msg_in[TEST_PORTAL_SIZE];
-	PRIVATE char msg_out[TEST_PORTAL_SIZE];
+	int inportals[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	int outportals[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	PRIVATE char msg_in[PORTAL_SIZE];
+	PRIVATE char msg_out[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1633,7 +1610,7 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+		for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 		{
 			test_assert((inportals[j] = kportal_create(local, j)) >= 0);
 			test_assert((outportals[j] = kportal_open(local, remote, j)) >= 0);
@@ -1643,14 +1620,14 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, k) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 			}
 		}
@@ -1658,19 +1635,19 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, k) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 				}
 			}
 		}
 
-		for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+		for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 		{
 			test_assert(kportal_close(outportals[j]) == 0);
 			test_assert(kportal_unlink(inportals[j]) == 0);
@@ -1742,12 +1719,6 @@ PRIVATE void fence(struct fence *b)
 	}
 }
 
-#ifdef __mppa256__
-	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_THREAD_NPORTS (THREAD_MAX)
-#endif
-
 /*============================================================================*
  * Stress Test: Portal Thread Multiplexing Broadcast                          *
  *============================================================================*/
@@ -1759,7 +1730,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 	int remote;
 	int nports;
 	int portalids[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -1784,7 +1755,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -1814,7 +1785,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 				}
 
@@ -1865,7 +1836,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 	int local;
 	int remote;
 	int portalids[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -1890,7 +1861,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -1920,7 +1891,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 
 				}
@@ -1973,8 +1944,8 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 	int nports;
 	int inportals[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
 	int outportals[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
-	char msg_in[TEST_PORTAL_SIZE];
-	char msg_out[TEST_PORTAL_SIZE];
+	char msg_in[PORTAL_SIZE];
+	char msg_out[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -2006,10 +1977,10 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 				{
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
 				fence(&_fence);
@@ -2021,11 +1992,11 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 			{
 				for (int k = 0; k < nports; ++k)
 				{
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 				}
 
@@ -2075,7 +2046,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 	int local;
 	int nports;
 	int portalids[TEST_THREAD_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -2098,7 +2069,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -2128,7 +2099,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				{
 					message[0] = 0;
 					test_assert(kportal_allow(portalids[k], local, ((tid - 1) + k * (THREAD_MAX - 1))) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == 1);
 				}
 
@@ -2178,7 +2149,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 	int local;
 	int nports;
 	int portalids[TEST_THREAD_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -2202,7 +2173,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -2231,7 +2202,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				{
 					message[0] = 0;
 					test_assert(kportal_allow(portalids[k], local, k) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == 1);
 
 				}

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -28,6 +28,41 @@
 	#include <nanvix/sys/thread.h>
 
 	/**
+     * @brief Test's parameters
+     */
+    #define NR_NODES       2
+    #define MASTER_NODENUM 0
+    #ifdef __mppa256__
+        #define SLAVE_NODENUM  8
+    #else
+        #define SLAVE_NODENUM  1
+    #endif
+
+    #ifdef __mppa256__
+        #define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
+    #else
+        #define TEST_THREAD_NPORTS (THREAD_MAX)
+    #endif
+
+    #define NSETUPS 10
+    #define NCOMMUNICATIONS 100
+
+    /**
+     * @brief Portal message size
+     */
+    #define PORTAL_SIZE (1 * KB)
+
+	/**
+     * @brief Portal message size
+     */
+    #define MAILBOX_SIZE (KMAILBOX_MESSAGE_SIZE)
+
+    /**
+     * @brief Max number of nodes involved.
+     */
+    #define MAX_NUM_NODES PROCESSOR_NOC_NODES_NUM
+
+	/**
 	 * @brief Number of iterations in stress tests.
 	 */
 	#define NITERATIONS 10
@@ -91,5 +126,10 @@
 			kshutdown() /* noop */;                   \
 		}                                             \
 	}
+
+	/**
+     * @brief Horizontal line.
+     */
+    extern const char *HLINE;
 
 #endif /* _TEST_H_  */


### PR DESCRIPTION
# Description #
In this PR, some common constants defined in the multiple IKC test files were generalized and put into `test.h`, to padronize tests executions. Now, all important parameters of execution for these tests are on the same file, permitting to apply them to all over tests on a single execution.