### PR TITLE
[ikc] Breaking Large Transfers Using Portals

### DIFF
--- a/src/test/test.h
+++ b/src/test/test.h
@@ -30,27 +30,27 @@
 	/**
      * @brief Test's parameters
      */
+	/**@{*/
     #define NR_NODES       2
     #define MASTER_NODENUM 0
-    #ifdef __mppa256__
-        #define SLAVE_NODENUM  8
-    #else
-        #define SLAVE_NODENUM  1
-    #endif
-
-    #ifdef __mppa256__
-        #define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-    #else
-        #define TEST_THREAD_NPORTS (THREAD_MAX)
-    #endif
-
+#ifdef __mppa256__
+	#define SLAVE_NODENUM  8
+	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
+#else
+	#define SLAVE_NODENUM  1
+	#define TEST_THREAD_NPORTS (THREAD_MAX)
+#endif
     #define NSETUPS 10
     #define NCOMMUNICATIONS 100
+	/**@}*/
 
     /**
-     * @brief Portal message size
+     * @name Portal sizes.
      */
-    #define PORTAL_SIZE (1 * KB)
+	/**@{*/
+    #define PORTAL_SIZE       (1 * KB)                            /**< Small size. */
+	#define PORTAL_SIZE_LARGE (HAL_PORTAL_MAX_SIZE + PORTAL_SIZE) /**< Large size. */
+	/**@}*/
 
 	/**
      * @brief Portal message size


### PR DESCRIPTION
In this PR, I introduce user-side features to support the communication of arbitrary sizes through the portal.

I made only available on synchronous communication because is difficult to support it on asynchronous on account of the current behavior. For instance, when a wait function returns with `1`, we must try again a aread/awrite because the portal system didn't receive the right message. At this point, I suppose that we must change the return value for `-EAGAIN` to be more expressive.

## Related issue
[[ikc] Supoprt for Arbitrarly Large Portal Transfers](https://github.com/nanvix/libnanvix/issues/26)

## Submodule dependency
[Enhancement: Ordered and auxiliary mbuffer pool. (Microkernel PR)](https://github.com/nanvix/microkernel/pull/247)