### PR TITLE
[ikc] Generic Barrier

### DIFF
--- a/include/nanvix/runtime/barrier.h
+++ b/include/nanvix/runtime/barrier.h
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_RUNTIME_BARRIER_H_
+#define NANVIX_RUNTIME_BARRIER_H_
+
+	/**
+	 * @brief Barrier
+	 */
+	typedef struct
+	{
+		int leader;   /**< Leader Node      */
+		int syncs[2]; /**< Underlying Syncs */
+	} barrier_t;
+
+	/**
+	 * @brief NULL Barrier
+	 */
+	#define BARRIER_NULL ((barrier_t) { .leader = -1, .syncs[0] = -1, .syncs[1] = -1 })
+
+	/**
+	 * @brief Asserts if a barrier is invalid.
+	 *
+	 * @param x Target barrier.
+	 */
+	#define BARRIER_IS_VALID(x) \
+		(!((barrier.leader < 0) || (barrier.syncs[0] < 0 || (barrier.syncs[1] < 0))))
+
+	/**
+	 * @brief Creates a barrier.
+	 *
+	 * @returns Upons sucessful completion a newly created barrier is
+	 * returned. Upon failure BARRIER_NULL is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	extern barrier_t barrier_create(const int *nodes, int nnodes);
+
+	/**
+	 * @brief Destroys a barrier.
+	 *
+	 * @param barrier Target barrier.
+	 *
+	 * @returns Upon sucessful completion, zero is returned. Upon failure a
+	 * negative errorcode is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	extern int barrier_destroy(barrier_t barrier);
+
+	/**
+	 * @brief Waits on a barrier.
+	 *
+	 * @param barrier Target barrier.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon failure,
+	 * a negative error code is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	extern int barrier_wait(barrier_t barrier);
+
+#endif /* NANVIX_RUNTIME_BARRIER_H_ */

--- a/include/nanvix/runtime/stdikc.h
+++ b/include/nanvix/runtime/stdikc.h
@@ -35,13 +35,6 @@
  *============================================================================*/
 
 	/**
-	 * @brief Gets the kernel standard sync.
-	 *
-	 * @return The kernel standard sync.
-	 */
-	extern int stdsync_get(void);
-
-	/**
 	 * @brief Waits/Releases the standard kernel fence.
 	 *
 	 * @return Upon successful completion, zero is returned. Upon

--- a/src/libnanvix/ikc/barrier.c
+++ b/src/libnanvix/ikc/barrier.c
@@ -1,0 +1,159 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/sys/sync.h>
+
+#if __TARGET_HAS_SYNC
+
+#include <nanvix/sys/thread.h>
+#include <nanvix/runtime/stdikc.h>
+#include <nanvix/runtime/barrier.h>
+
+/**
+ * The barrier_create() function creates a barrier between the nodes
+ * listed in the array pointed to by @p nodes.
+ */
+barrier_t barrier_create(const int *nodes, int nnodes)
+{
+	barrier_t barrier;
+
+	/* Invalid list of nodes. */
+	if (nodes == NULL)
+		return (BARRIER_NULL);
+
+	/* Invalid number of nodes. */
+	if (nnodes < 2)
+		return (BARRIER_NULL);
+
+	/* Leader. */
+	if (knode_get_num() == nodes[0])
+	{
+		barrier.syncs[0] = ksync_create(
+			nodes,
+			nnodes,
+			SYNC_ALL_TO_ONE
+		);
+		barrier.syncs[1] = ksync_open(
+			nodes,
+			nnodes,
+			SYNC_ONE_TO_ALL
+		);
+	}
+
+	/* Follower. */
+	else
+	{
+		barrier.syncs[0] = ksync_open(
+			nodes,
+			nnodes,
+			SYNC_ALL_TO_ONE
+		);
+		barrier.syncs[1] = ksync_create(
+			nodes,
+			nnodes,
+			SYNC_ONE_TO_ALL
+		);
+	}
+
+	barrier.leader = nodes[0];
+
+	return (barrier);
+}
+
+/**
+ * The barrier_destroy() function closes underlying resources of the
+ * barrier @p barrier.
+ */
+int barrier_destroy(barrier_t barrier)
+{
+	int ret;
+	int err;
+
+	/* Invalid barrier. */
+	if (!BARRIER_IS_VALID(barrier))
+		return (-EINVAL);
+
+	ret = 0;
+
+	/* Leader. */
+	if (knode_get_num() == barrier.leader)
+	{
+		err = ksync_unlink(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_close(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	/* Follower. */
+	else
+	{
+		err = ksync_close(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_unlink(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	return (ret);
+}
+
+/**
+ * The barrier_wait() function causes the calling peer to block
+ * until all other participants of the barrier @p barrier have reached
+ * it.
+ */
+int barrier_wait(barrier_t barrier)
+{
+	int ret;
+	int err;
+
+	/* Invalid barrier. */
+	if (!BARRIER_IS_VALID(barrier))
+		return (-EINVAL);
+
+	ret = 0;
+
+	/* Leader */
+	if (knode_get_num() == barrier.leader)
+	{
+		err = ksync_wait(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_signal(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	/* Follower. */
+	else
+	{
+		err = ksync_signal(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_wait(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	return (ret);
+}
+
+#else
+extern int make_iso_compilers_happy;
+#endif /* __TARGET_HAS_MAILBOX */

--- a/src/libnanvix/ikc/stdsync.c
+++ b/src/libnanvix/ikc/stdsync.c
@@ -208,18 +208,6 @@ int stdsync_fence(void)
 	return (0);
 }
 
-/**
- * @todo TODO: provide a detailed description for this function.
- */
-int stdsync_get(void)
-{
-	int tid;
-
-	if ((tid = kthread_self()) > THREAD_MAX)
-		return (-1);
-
-	return (__stdbarrier[tid][0]);
-}
 
 #else
 extern int make_iso_compilers_happy;


### PR DESCRIPTION
# Description

In this pull request I introduce a generic barrier implementation on top of `ksync`. Furthermore I have changed the implementation of our `stdsync` to use this barrier primitive as backend.

# Related Issues

- Closes https://github.com/nanvix/libnanvix/issues/33