### PR TITLE
[test]  Enable Stress Tests in Thread System

### DIFF
--- a/src/test/test.h
+++ b/src/test/test.h
@@ -65,7 +65,7 @@
 	/**
 	 * @brief Number of iterations in stress tests.
 	 */
-	#define NITERATIONS 10
+	#define NITERATIONS 1000
 
 	/**
 	 * @brief Number of threads to spawn in stress tests.


### PR DESCRIPTION
In this PR, I fix a function name and enable stress tests of the kthread system.

## Related issue

- Closes https://github.com/nanvix/libnanvix/issues/36

## Related Submodule PR (Microkernel)
[[tm] Bugfix: Stress tests unable to create kernel threads](https://github.com/nanvix/microkernel/pull/253)