### PR TITLE
[ikc] Sync and Portal Using Mailboxes

### DIFF
--- a/include/nanvix/sys/mailbox.h
+++ b/include/nanvix/sys/mailbox.h
@@ -34,6 +34,14 @@
 	#include <posix/sys/types.h>
 
 	/**
+	 * @brief If the configuration of IKC systems is missing, then disable
+	 * the implementation that uses only mailboxes.
+	 */
+	#ifndef __NANVIX_IKC_USES_ONLY_MAILBOX
+	#define __NANVIX_IKC_USES_ONLY_MAILBOX 0
+	#endif
+
+	/**
 	 * @brief Initializes the user-side of the mailbox system.
 	 */
 	extern void kmailbox_init(void);

--- a/include/nanvix/sys/mailbox.h
+++ b/include/nanvix/sys/mailbox.h
@@ -34,6 +34,11 @@
 	#include <posix/sys/types.h>
 
 	/**
+	 * @brief Initializes the user-side of the mailbox system.
+	 */
+	extern void kmailbox_init(void);
+
+	/**
 	 * @brief Creates an input mailbox.
 	 *
 	 * @param local Target local NoC node.

--- a/include/nanvix/sys/noc.h
+++ b/include/nanvix/sys/noc.h
@@ -39,6 +39,7 @@
 	extern int knode_get_num(void);
 	extern int kcluster_get_num(void);
 	extern int kcomm_get_port(int, int);
+	extern void knoc_init(void);
 	/**@}*/
 
 #endif /* NANVIX_SYS_NOC_H_ */

--- a/include/nanvix/sys/portal.h
+++ b/include/nanvix/sys/portal.h
@@ -35,6 +35,11 @@
 	#include <posix/stdint.h>
 
 	/**
+	 * @brief Initializes the user-side of the portal system.
+	 */
+	extern void kportal_init(void);
+
+	/**
 	 * @brief Creates a portal.
 	 *
 	 * @param local      Logic ID of the Local Node.

--- a/include/nanvix/sys/portal.h
+++ b/include/nanvix/sys/portal.h
@@ -35,6 +35,14 @@
 	#include <posix/stdint.h>
 
 	/**
+	 * @brief If the configuration of IKC systems is missing, then disable
+	 * the implementation that uses only mailboxes.
+	 */
+	#ifndef __NANVIX_IKC_USES_ONLY_MAILBOX
+		#define __NANVIX_IKC_USES_ONLY_MAILBOX 0
+	#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
+
+	/**
 	 * @brief Initializes the user-side of the portal system.
 	 */
 	extern void kportal_init(void);
@@ -164,6 +172,19 @@
 	 * a negative error code is returned instead.
 	 */
 	extern int kportal_ioctl(int portalid, unsigned request, ...);
+
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+
+	/**
+	 * @brief Gets local port attached to a portal.
+	 *
+	 * @param portalid Portal ID
+	 *
+	 * @returns Upon successful completion, local port attached to portalid.
+	 */
+	extern int kportal_get_port(int portalid);
+
+#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
 
 #endif /* NANVIX_SYS_PORTAL_H_ */
 

--- a/include/nanvix/sys/portal.h
+++ b/include/nanvix/sys/portal.h
@@ -105,7 +105,7 @@
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	extern int kportal_read(int portalid, void * buffer, size_t size);
+	extern ssize_t kportal_read(int portalid, void * buffer, size_t size);
 
 	/**
 	 * @brief Asynchronously reads data from a portal.
@@ -117,7 +117,7 @@
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	extern int kportal_aread(int portalid, void * buffer, size_t size);
+	extern ssize_t kportal_aread(int portalid, void * buffer, size_t size);
 
 	/**
 	 * @brief Writes data to a portal.
@@ -129,7 +129,7 @@
 	 * @returns Upon successful, zero is returned. Upon failure, a
 	 * negative error code is returned instead.
 	 */
-	extern int kportal_write(int portalid, const void * buffer, size_t size);
+	extern ssize_t kportal_write(int portalid, const void * buffer, size_t size);
 
 	/**
 	 * @brief Asynchronously writes data to a portal.
@@ -141,7 +141,7 @@
 	 * @returns Upon successful, zero is returned. Upon failure, a
 	 * negative error code is returned instead.
 	 */
-	extern int kportal_awrite(int portalid, const void * buffer, size_t size);
+	extern ssize_t kportal_awrite(int portalid, const void * buffer, size_t size);
 
 	/**
 	 * @brief Waits for an asynchronous operation on a portal to complete.

--- a/include/nanvix/sys/sync.h
+++ b/include/nanvix/sys/sync.h
@@ -34,6 +34,14 @@
 	#include <posix/sys/types.h>
 
 	/**
+	 * @brief If the configuration of IKC systems is missing, then disable
+	 * the implementation that uses only mailboxes.
+	 */
+	#ifndef __NANVIX_IKC_USES_ONLY_MAILBOX
+	#define __NANVIX_IKC_USES_ONLY_MAILBOX 0
+	#endif
+
+	/**
 	 * @brief Initializes the user-side of the synchronization system.
 	 */
 	extern void ksync_init(void);

--- a/include/nanvix/sys/sync.h
+++ b/include/nanvix/sys/sync.h
@@ -33,7 +33,12 @@
 	#include <nanvix/kernel/kernel.h>
 	#include <posix/sys/types.h>
 
-		/**
+	/**
+	 * @brief Initializes the user-side of the synchronization system.
+	 */
+	extern void ksync_init(void);
+
+	/**
 	 * @brief Creates a synchronization point.
 	 *
 	 * @param nodes  Logic IDs of Target Nodes.

--- a/makefile
+++ b/makefile
@@ -92,6 +92,9 @@ export CFLAGS += -Wno-unused-function
 export CFLAGS += -I $(INCDIR)
 export CFLAGS += -I $(ROOTDIR)/src/lwip/src/include
 
+# Enable sync and portal implementation that uses mailboxes
+export CFLAGS += -D__NANVIX_IKC_USES_ONLY_MAILBOX=0
+
 # Additional C Flags
 include $(BUILDDIR)/makefile.cflags
 

--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -290,6 +290,18 @@ int kmailbox_ioctl(int mbxid, unsigned request, ...)
 	return (ret);
 }
 
+/*============================================================================*
+ * kmailbox_init()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kmailbox_init() Initializes mailbox system.
+ */
+PUBLIC void kmailbox_init(void)
+{
+	kprintf("[user][mailbox] Initializes mailbox module");
+}
+
 #else
 extern int make_iso_compilers_happy;
 #endif /* __TARGET_HAS_MAILBOX */

--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -118,7 +118,7 @@ int kmailbox_close(int mbxid)
  * @details The kmailbox_awrite() asynchronously write @p size bytes
  * of data pointed to by @p buffer to the output mailbox @p mbxid.
  */
-ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
+ssize_t kmailbox_awrite(int mbxid, const void * buffer, size_t size)
 {
 	int ret;
 
@@ -132,7 +132,7 @@ ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
 			NR_mailbox_awrite,
 			(word_t) mbxid,
 			(word_t) buffer,
-			(word_t) KMAILBOX_MESSAGE_SIZE
+			(word_t) size
 		);
 	} while ((ret == -ETIMEDOUT) || (ret == -EAGAIN) || (ret == -EBUSY));
 
@@ -147,7 +147,7 @@ ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
  * @details The kmailbox_aread() asynchronously read @p size bytes of
  * data pointed to by @p buffer from the input mailbox @p mbxid.
  */
-ssize_t kmailbox_aread(int mbxid, void *buffer, size_t size)
+ssize_t kmailbox_aread(int mbxid, void * buffer, size_t size)
 {
 	int ret;
 
@@ -161,7 +161,7 @@ ssize_t kmailbox_aread(int mbxid, void *buffer, size_t size)
 			NR_mailbox_aread,
 			(word_t) mbxid,
 			(word_t) buffer,
-			(word_t) KMAILBOX_MESSAGE_SIZE
+			(word_t) size
 		);
 	} while ((ret == -ETIMEDOUT) || (ret == -EBUSY) || (ret == -ENOMSG));
 
@@ -198,10 +198,9 @@ int kmailbox_wait(int mbxid)
  *
  * @todo Uncomment kmailbox_wait() call when microkernel properly supports it.
  */
-ssize_t kmailbox_write(int mbxid, const void *buffer, size_t size)
+ssize_t kmailbox_write(int mbxid, const void * buffer, size_t size)
 {
 	int ret;
-	char buffer2[KMAILBOX_MESSAGE_SIZE];
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -211,9 +210,7 @@ ssize_t kmailbox_write(int mbxid, const void *buffer, size_t size)
 	if ((size == 0) || (size > KMAILBOX_MESSAGE_SIZE))
 		return (-EINVAL);
 
-	kmemcpy(buffer2, buffer, size);
-
-	if ((ret = kmailbox_awrite(mbxid, buffer2, KMAILBOX_MESSAGE_SIZE)) < 0)
+	if ((ret = kmailbox_awrite(mbxid, buffer, size)) < 0)
 		return (ret);
 
 	if ((ret = kmailbox_wait(mbxid)) < 0)
@@ -230,10 +227,9 @@ ssize_t kmailbox_write(int mbxid, const void *buffer, size_t size)
  * @details The kmailbox_read() synchronously read @p size bytes of
  * data pointed to by @p buffer from the input mailbox @p mbxid.
  */
-ssize_t kmailbox_read(int mbxid, void *buffer, size_t size)
+ssize_t kmailbox_read(int mbxid, void * buffer, size_t size)
 {
 	int ret;
-	char buffer2[KMAILBOX_MESSAGE_SIZE];
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -246,15 +242,13 @@ ssize_t kmailbox_read(int mbxid, void *buffer, size_t size)
 	/* Repeat while reading valid messages for another ports. */
 	do
 	{
-		if ((ret = kmailbox_aread(mbxid, buffer2, KMAILBOX_MESSAGE_SIZE)) < 0)
+		if ((ret = kmailbox_aread(mbxid, buffer, size)) < 0)
 			return (ret);
 	} while ((ret = kmailbox_wait(mbxid)) > 0);
 
 	/* Wait failed. */
 	if (ret < 0)
 		return (ret);
-
-	kmemcpy(buffer, buffer2, size);
 
 	return (size);
 }

--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -40,6 +40,11 @@ int kmailbox_create(int local, int port)
 {
 	int ret;
 
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	if (!WITHIN(port, 0, KMAILBOX_PORT_NR))
+		return (-EINVAL);
+#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
+
 	ret = kcall2(
 		NR_mailbox_create,
 		(word_t) local,
@@ -60,6 +65,11 @@ int kmailbox_create(int local, int port)
 int kmailbox_open(int remote, int remote_port)
 {
 	int ret;
+
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	if (!WITHIN(remote_port, 0, KMAILBOX_PORT_NR))
+		return (-EINVAL);
+#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
 
 	ret = kcall2(
 		NR_mailbox_open,

--- a/src/libnanvix/ikc/mportal.c
+++ b/src/libnanvix/ikc/mportal.c
@@ -1,0 +1,1724 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define __NEED_RESOURCE
+
+#include <nanvix/kernel/kernel.h>
+
+#if __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX
+
+#include <nanvix/sys/perf.h>
+#include <nanvix/sys/noc.h>
+#include <nanvix/sys/mailbox.h>
+#include <nanvix/sys/portal.h>
+#include <posix/errno.h>
+
+/**
+ * @brief Indicates if kportal_init is called.
+ */
+PRIVATE bool kportal_is_initialized = false;
+
+/**
+ * @name Protections.
+ */
+/**@{*/
+PRIVATE spinlock_t global_lock            = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t local_lock             = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t allow_lock             = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t buffer_lock            = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t read_lock[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = SPINLOCK_UNLOCKED
+};
+PRIVATE spinlock_t write_lock[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = SPINLOCK_UNLOCKED
+};
+/**@}*/
+
+/**
+ * @name Mailbox channels.
+ */
+/**@{*/
+PRIVATE int mallow_in = -1;
+PRIVATE int mallow_outs[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+PRIVATE int mdata_ins[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+PRIVATE int mdata_outs[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+/**@}*/
+
+/**
+ * @name Fair use of read channels.
+ */
+/**@{*/
+PRIVATE struct resource read_channels[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = RESOURCE_INITIALIZER
+};
+PRIVATE struct resource write_channels[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = RESOURCE_INITIALIZER
+};
+/**@}*/
+
+/**
+ * @brief Write control.
+ */
+PRIVATE bool remote_is_allowed[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = false
+};
+
+/*============================================================================*
+ * Portal configuration                                                       *
+ *============================================================================*/
+
+/**
+ * @name Configuration macros.
+ */
+/**@{*/
+#define MPORTAL_CONFIG_SIZE (sizeof(struct mportal_config))           /**< Size of config struct. */
+#define MPORTAL_CONFIG_NULL ((struct mportal_config){-1, -1, -1, -1}) /**< Invalid configuration. */
+/**@}*/
+
+/**
+ * @brief Configuration structure.
+ */
+struct mportal_config
+{
+	int local;       /**< Local nodenum.  */
+	int local_port;  /**< Local port id.  */
+	int remote;      /**< Remote nodenum. */
+	int remote_port; /**< Remote port id. */
+};
+
+/*============================================================================*
+ * Portal structure                                                           *
+ *============================================================================*/
+
+/**
+ * @brief Table of portals.
+ */
+PRIVATE struct mportal
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource;     /**< Generic resource information.    */
+	int refcount;                 /**< Counter of references (Avoided). */
+
+	/**
+	 * @name Communication.
+	 */
+	/**@{*/
+	int mallow;                   /**< Mailbox channel to allow.        */
+	int mdata;                    /**< Mailbox channel to data.         */
+	struct mportal_config config; /**< Configuration.                   */
+	/**@}*/
+
+	/**
+	 * @name Statistics.
+	 */
+	/**@{*/
+	size_t volume;                /**< Volume.                          */
+	uint64_t latency;             /**< Latency.                         */
+	/**@}*/
+} ALIGN(sizeof(dword_t)) mportals[KPORTAL_MAX] = {
+	[0 ... (KPORTAL_MAX - 1)] = {
+		.resource  = RESOURCE_INITIALIZER,
+		.refcount  = 0,
+		.mallow    = -1,
+		.mdata     = -1,
+		.volume    = 0ULL,
+		.latency   = 0ULL,
+		.config    = MPORTAL_CONFIG_NULL,
+	},
+};
+
+/**
+ * @brief Portal pool.
+ */
+PRIVATE const struct resource_pool mportalpool = {
+	mportals, (KPORTAL_MAX), sizeof(struct mportal)
+};
+
+/*============================================================================*
+ * Portal message                                                             *
+ *============================================================================*/
+
+/**
+ * @name Portal message macros.
+ */
+/**@{*/
+#define MPORTAL_MESSAGE_SIZE      (sizeof(struct mportal_message)) /**< Size of config struct. */
+#define MPORTAL_MESSAGE_DATA_SIZE (KMAILBOX_MESSAGE_SIZE - 6)      /**< Max data size.         */
+/**@}*/
+
+/**
+ * @brief Portal message structure.
+ */
+struct mportal_message
+{
+	/**
+	 * @name Control.
+	 */
+	/**@{*/
+	char header : 1; /**< Indicates if contains the a valid config. */
+	char eof    : 1; /**< Indicates if is the last message.         */
+	char unused : 6; /**< Unused.                                   */
+	char size;       /**< Data size.                                */
+	/**@}*/
+
+	/**
+	 * @name Data.
+	 */
+	/**@{*/
+	union
+	{
+		struct mportal_config config;         /**< Configuration.   */
+		char data[MPORTAL_MESSAGE_DATA_SIZE]; /**< Data buffer.     */
+	} _;             /**< Abstract union.                           */
+	/**@}*/
+};
+
+/*============================================================================*
+ * Portal Port (TX only)                                                      *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * Structure and variables                                                    *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Portal port structure.
+ */
+PRIVATE struct mportal_port
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource; /**< Generic resource information. */
+} mports[HAL_PORTAL_OPEN_MAX][KPORTAL_PORT_NR] = {
+	[0 ... (HAL_PORTAL_OPEN_MAX - 1)] = {
+		[0 ... (KPORTAL_PORT_NR - 1)] = {
+			.resource = RESOURCE_INITIALIZER,
+		},
+	},
+};
+
+/*----------------------------------------------------------------------------*
+ * kportal_port_alloc()                                                       *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int kportal_port_alloc(int remote)
+{
+	for (unsigned i = 0; i < KPORTAL_PORT_NR; ++i)
+	{
+		if (!resource_is_used(&mports[remote][i].resource))
+		{
+			resource_set_used(&mports[remote][i].resource);
+			return (i);
+		}
+	}
+
+	return (-EBUSY);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_port_release()                                                     *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int kportal_port_release(int remote, int portid)
+{
+	KASSERT(WITHIN(portid, 0, KPORTAL_PORT_NR));
+	KASSERT(resource_is_used(&mports[remote][portid].resource));
+	resource_set_unused(&mports[remote][portid].resource);
+	return (0);
+}
+
+/*============================================================================*
+ * kportal_search()                                                           *
+ *============================================================================*/
+
+PRIVATE void kportal_print_message(char * message, struct mportal_config * config)
+{
+	kprintf("[portal] %s (local:%d, local_port:%d, remote:%d, remote_port:%d)",
+		message,
+		config->local,
+		config->local_port,
+		config->remote,
+		config->remote_port
+	);
+}
+
+/*============================================================================*
+ * Portal Buffer                                                              *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * Structures and variables                                                   *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @name Portal buffer macros.
+ */
+/**@{*/
+#define MPORTAL_BUFFER_SIZE (KPORTAL_MESSAGE_DATA_SIZE) /**< Maximum buffer size.       */
+#define MPORTAL_BUFFER_MAX  (40)                        /**< Maximum number of buffers. */
+/**@}*/
+
+/**
+ * @brief Portal buffer structure.
+ */
+PRIVATE struct mportal_buffer
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource;       /**< Generic resource information.    */
+
+	/**
+	 * @name Control.
+	 */
+	/**@{*/
+	uint64_t age;                   /**< Buffer age.                      */
+	size_t seq;                     /**< Sequence number.                 */
+	size_t size;                    /**< Valid data size.                 */
+	struct mportal_config config;   /**< Configuration                    */
+	struct mportal_buffer * next;   /**< Next buffer of the sequence.     */
+	/**@}*/
+
+	/**
+	 * @brief Data.
+	 */
+	char data[MPORTAL_BUFFER_SIZE]; /**< Data buffer.                     */
+} mbuffers[MPORTAL_BUFFER_MAX] = {
+	[0 ... (MPORTAL_BUFFER_MAX - 1)] = {
+		.resource = RESOURCE_INITIALIZER,
+		.age    = ~(0ULL),
+		.seq    = ~(0ULL),
+		.size   = 0ULL,
+		.next   = NULL,
+		.config = MPORTAL_CONFIG_NULL,
+		.data   = {0, },
+	},
+};
+
+/**
+ * @brief Age counter of the portal buffers.
+ */
+PRIVATE uint64_t mbuffer_next_age = 0ULL;
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_alloc()                                                     *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * kportal_buffer_alloc(
+	struct mportal_buffer * previous,
+	struct mportal_config * config
+)
+{
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	buf = NULL;
+
+	if (config == NULL)
+		return (NULL);
+
+	spinlock_lock(&buffer_lock);
+
+		for (size_t i = 0; i < MPORTAL_BUFFER_MAX; ++i)
+		{
+			if (resource_is_used(&mbuffers[i].resource))
+				continue;
+
+			buf = &mbuffers[i];
+
+			if (previous == NULL)
+				buf->seq = 0;
+			else
+			{
+				buf->seq = previous->seq + 1;
+				previous->next = buf;
+			}
+
+			buf->config = *config;
+			buf->size   = 0ULL;
+			buf->next   = NULL;
+			buf->age    = mbuffer_next_age++;
+			resource_set_used(&buf->resource);
+
+			break;
+		}
+
+	spinlock_unlock(&buffer_lock);
+
+	return (buf);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_buffer_release()                                                *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * do_kportal_buffer_release(struct mportal_buffer * buf)
+{
+	struct mportal_buffer * next; /* Auxiliar buffer pointer. */
+
+	if (buf == NULL)
+		return (NULL);
+
+	if (!resource_is_used(&buf->resource))
+		return (NULL);
+
+	next = buf->next;
+
+	buf->config = MPORTAL_CONFIG_NULL;
+	buf->seq    = -1;
+	buf->size   = 0ULL;
+	buf->next   = NULL;
+	buf->age    = ~(0ULL);
+	resource_set_unused(&buf->resource);
+
+	return (next);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_release()                                                   *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * kportal_buffer_release(struct mportal_buffer * buf)
+{
+	struct mportal_buffer * next; /* Auxiliar buffer pointer. */
+
+	if (buf == NULL)
+		return (NULL);
+
+	spinlock_lock(&buffer_lock);
+		next = do_kportal_buffer_release(buf);
+	spinlock_unlock(&buffer_lock);
+
+	return (next);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_buffer_search()                                                 *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * do_kportal_buffer_search(struct mportal * portal)
+{
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	if (!node_is_local(portal->config.local))
+		kportal_print_message("kportal_search failed", &portal->config);
+
+	/* Sanity checks. */
+	KASSERT(node_is_local(portal->config.local));
+
+	buf = NULL;
+
+	for (size_t i = 0; i < MPORTAL_BUFFER_MAX; ++i)
+	{
+		if (!resource_is_used(&mbuffers[i].resource))
+			continue;
+
+		if (portal->config.local != mbuffers[i].config.remote)
+			continue;
+
+		if (portal->config.local_port != mbuffers[i].config.remote_port)
+			continue;
+
+		/* Is it a read operation? */
+		if (portal->config.remote != -1)
+		{
+			if (portal->config.remote != mbuffers[i].config.local)
+				continue;
+
+			if (portal->config.remote_port != mbuffers[i].config.local_port)
+				continue;
+
+			if (mbuffers[i].seq != 0)
+				continue;
+
+			if (buf != NULL && buf->age < mbuffers[i].age)
+				continue;
+		}
+
+		buf = &mbuffers[i];
+
+		/* Is it a find the first operation? */
+		if (portal->config.remote == -1)
+			break;
+	}
+
+	return (buf);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_search()                                                    *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * kportal_buffer_search(struct mportal * portal)
+{
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	if (portal == NULL)
+		return (NULL);
+
+	spinlock_lock(&buffer_lock);
+		buf = do_kportal_buffer_search(portal);
+	spinlock_unlock(&buffer_lock);
+
+	return (buf);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_read()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t kportal_buffer_read(
+	struct mportal * portal,
+	void ** buffer,
+	size_t * remainder,
+	struct mportal_buffer ** previous
+)
+{
+	uint64_t t0;                 /* Clock value.             */
+	uint64_t t1;                 /* Clock value.             */
+	size_t copied;               /* Amount of data copied.   */
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	copied = 0ULL;
+	buf    = NULL;
+
+	if (buffer == NULL || *buffer == NULL)
+		return (-EINVAL);
+
+	spinlock_lock(&buffer_lock);
+
+		buf = (*previous) ? (*previous)->next : do_kportal_buffer_search(portal);
+
+		while (buf)
+		{
+			/* Sanity check. */
+			if (buf->size > *remainder)
+			{
+				/**
+				 * Discard entire message because it lost the previous ones.
+				 * TODO: Recover the message from "copied" buffer.
+				 **/
+				if (buf->seq > 0)
+				{
+					while (do_kportal_buffer_release(buf));
+
+					if (*previous)
+					{
+						do_kportal_buffer_release(*previous);
+						*previous = NULL;
+					}
+				}
+
+				copied = (-EINVAL);
+				goto error;
+			}
+
+			/* Copy the message. */
+			kclock(&t0);
+				kmemcpy(*buffer, buf->data, buf->size);
+			kclock(&t1);
+			portal->latency += (t1 - t0);
+
+			/* Updates parameters. */
+			copied     += buf->size;
+			*buffer    += buf->size;
+			*remainder -= buf->size;
+
+			/* Updates previous buffer. */
+			*previous = (*previous) ? do_kportal_buffer_release(*previous) : buf;
+
+			/* Get next buffer. */
+			buf = (*previous)->next;
+		}
+
+		if ((*remainder == 0) && *previous)
+		{
+			do_kportal_buffer_release(*previous);
+			*previous = NULL;
+		}
+
+error:
+	spinlock_unlock(&buffer_lock);
+
+	return (copied);
+}
+
+/*============================================================================*
+ * kportal_search()                                                           *
+ *============================================================================*/
+
+PRIVATE int kportal_search(struct mportal_config * config, int input)
+{
+	if (!node_is_local(config->local))
+		kportal_print_message("kportal_search failed", config);
+
+	/* Sanity checks. */
+	KASSERT(node_is_local(config->local));
+
+	for (unsigned i = 0; i < KPORTAL_MAX; ++i)
+	{
+		if (!resource_is_used(&mportals[i].resource))
+			continue;
+
+		if (input)
+		{
+			if (!resource_is_readable(&mportals[i].resource))
+				continue;
+		}
+
+		/* Output. */
+		else if (!resource_is_writable(&mportals[i].resource))
+			continue;
+
+		if (mportals[i].config.local != config->local)
+			continue;
+
+		if (mportals[i].config.local_port != config->local_port)
+			continue;
+
+		if (!input)
+		{
+			if (mportals[i].config.remote != config->remote)
+				continue;
+
+			if (mportals[i].config.remote_port != config->remote_port)
+				continue;
+		}
+
+		return (i);
+	}
+
+	return (-EINVAL);
+}
+
+/*============================================================================*
+ * kportal_create()                                                           *
+ *============================================================================*/
+
+/**
+ * @details The kportal_create() function creates an input portal and
+ * attaches it to the local port @p local_port in the local NoC node @p
+ * local.
+ */
+PUBLIC int kportal_create(int local, int local_port)
+{
+	int portalid;                 /* Portal ID.            */
+	struct mportal_config config; /* Portal configuration. */
+
+	KASSERT(kportal_is_initialized);
+
+	/* Invalid local. */
+	if (!node_is_valid(local))
+		return (-EINVAL);
+
+	/* Invalid local number for the requesting core ID. */
+	if (!node_is_local(local))
+		return (-EINVAL);
+
+	/* Invalid portid. */
+	if (!WITHIN(local_port, 0, KPORTAL_PORT_NR))
+		return (-EINVAL);
+
+	/* Configures portal. */
+	config.local       = local;
+	config.local_port  = local_port;
+	config.remote      = -1;
+	config.remote_port = -1;
+
+	spinlock_lock(&global_lock);
+
+		/**
+		 * Previous create.
+		 * TODO: Adds mportals[portalid].refcount++ to enable multiples
+		 * creates of a same configuration.
+		 **/
+		if ((portalid = kportal_search(&config, true)) >= 0)
+			portalid = (-EBUSY);
+
+		/* First create. */
+		else if ((portalid = resource_alloc(&mportalpool)) >= 0)
+		{
+			mportals[portalid].refcount = 1;
+			mportals[portalid].volume   = 0ULL;
+			mportals[portalid].latency  = 0ULL;
+			mportals[portalid].config   = config;
+			resource_set_rdonly(&mportals[portalid].resource);
+		}
+
+	spinlock_unlock(&global_lock);
+
+	return (portalid);
+}
+
+/*============================================================================*
+ * kportal_allow()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_allow() function allow read data from a input portal
+ * associated with the NoC node @p remote.
+ */
+PUBLIC int kportal_allow(int portalid, int remote, int remote_port)
+{
+	int ret; /* Return value. */
+
+	ret = (-EINVAL);
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	/* Invalid local. */
+	if (!node_is_valid(remote))
+		return (-EINVAL);
+
+	/* Invalid portid. */
+	if (!WITHIN(remote_port, 0, KPORTAL_PORT_NR))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		/* Already allowed. */
+		if (mportals[portalid].config.remote != -1)
+			goto error;
+
+		mportals[portalid].mallow             = mallow_outs[remote];
+		mportals[portalid].mdata              = mdata_ins[remote];
+		mportals[portalid].config.remote      = remote;
+		mportals[portalid].config.remote_port = remote_port;
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_open()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_open() function opens an output portal to the remote
+ * NoC node @p remote and attaches it to the local NoC node @p local.
+ */
+PUBLIC int kportal_open(int local, int remote, int remote_port)
+{
+	int portalid;                 /* Portal ID.            */
+	int local_port;               /* Portal port.          */
+	struct mportal_config config; /* Portal configuration. */
+
+	KASSERT(kportal_is_initialized);
+
+	/* Invalid local. */
+	if (!node_is_valid(local))
+		return (-EINVAL);
+
+	/* Invalid remote. */
+	if (!node_is_valid(remote))
+		return (-EINVAL);
+
+	/* Invalid local number for the requesting core ID. */
+	if (!node_is_local(local))
+		return (-EINVAL);
+
+	/* Invalid portid. */
+	if (!WITHIN(remote_port, 0, KPORTAL_PORT_NR))
+		return (-EINVAL);
+
+	/* Configures portal. */
+	config.local       = local;
+	config.remote      = remote;
+	config.remote_port = remote_port;
+
+	spinlock_lock(&global_lock);
+
+		portalid = (-EBUSY);
+
+		/* Alloc a local port. */
+		if ((local_port = kportal_port_alloc(remote)) < 0)
+			goto error;
+
+		config.local_port  = local_port;
+
+		/**
+		 * Previous open.
+		 * TODO: Adds mportals[portalid].refcount++ to enable multiples
+		 * open of a same configuration.
+		 **/
+		if ((portalid = kportal_search(&config, false)) >= 0)
+			portalid = (-EBUSY);
+
+		/* First create. */
+		else if ((portalid = resource_alloc(&mportalpool)) >= 0)
+		{
+			mportals[portalid].mallow   = mallow_in;
+			mportals[portalid].mdata    = mdata_outs[remote];
+			mportals[portalid].refcount = 1;
+			mportals[portalid].volume   = 0;
+			mportals[portalid].latency  = 0;
+			mportals[portalid].config   = config;
+			resource_set_wronly(&mportals[portalid].resource);
+		}
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (portalid);
+}
+
+/*============================================================================*
+ * kportal_unlink()                                                           *
+ *============================================================================*/
+
+/**
+ * @details The kportal_unlink() function removes and releases the underlying
+ * resources associated to the input portal @p portalid.
+ */
+PUBLIC int kportal_unlink(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		/* Busy sync. */
+		if (kportal_buffer_search(&mportals[portalid]) != NULL)
+			goto error;
+
+		/* Decrement references. */
+		mportals[portalid].refcount--;
+
+		/* Releases resource (for now, refcount always is 0 here). */
+		if (!mportals[portalid].refcount)
+		{
+			mportals[portalid].mallow = -1;
+			mportals[portalid].mdata  = -1;
+			mportals[portalid].config = MPORTAL_CONFIG_NULL;
+			resource_free(&mportalpool, portalid);
+		}
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_close()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_close() function closes and releases the
+ * underlying resources associated to the output portal @p portalid.
+ */
+PUBLIC int kportal_close(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_writable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		/* Decrement references. */
+		mportals[portalid].refcount--;
+
+		/* Releases resource (for now, refcount always is 0 here). */
+		if (!mportals[portalid].refcount)
+		{
+			kportal_port_release(
+				mportals[portalid].config.remote,
+				mportals[portalid].config.local_port
+			);
+			mportals[portalid].mallow = -1;
+			mportals[portalid].mdata  = -1;
+			mportals[portalid].config = MPORTAL_CONFIG_NULL;
+			resource_free(&mportalpool, portalid);
+		}
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_aread()                                                            *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_aread()                                                         *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_aread(struct mportal * portal, void * buffer, size_t size)
+{
+	ssize_t ret;                    /* Return value.                           */
+	void * data;                    /* Auxiliar buffer pointer.                */
+	bool buffering;                 /* Define where the data will be store.    */
+	bool valid;                     /* Define if the messages will be ignored. */
+	size_t received;                /* Received data counter.                  */
+	struct mportal_buffer * buf;    /* Auxiliar buffer pointer.                */
+	struct mportal_message message; /* Message buffer.                         */
+	struct mportal_config config;   /* Configuration pointer.                  */
+
+	/* Valid portal. */
+	KASSERT(portal && node_is_valid(portal->config.remote));
+
+again:
+	spinlock_lock(&read_lock[portal->config.remote]);
+
+		buf       = NULL;
+		valid     = true;
+		buffering = false;
+		received  = size;
+
+		/* Reads buffered message. */
+		if ((ret = kportal_buffer_read(portal, &buffer, &received, &buf)) != 0)
+		{
+			/* Is it copied correctly? */
+			ret = (ret == ((ssize_t) size)) ? ((ssize_t) size) : (-EINVAL);
+			goto exit;
+		}
+
+		/* Is the channel busy? */
+		if (resource_is_busy(&read_channels[portal->config.remote]))
+		{
+			spinlock_unlock(&read_lock[portal->config.remote]);
+			goto again;
+		}
+
+		/* Set channel busy. */
+		resource_set_busy(&read_channels[portal->config.remote]);
+
+		/* Allows. */
+		if ((ret = kmailbox_write(portal->mallow, &portal->config, MPORTAL_CONFIG_SIZE)) < 0)
+			goto release;
+
+		/* Reads header. */
+		if ((ret = kmailbox_read(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+			goto release;
+
+		/* Sanity check. */
+		KASSERT(message.header || !message.eof);
+
+		/* Is the message to an existing portal? */
+		config.local       = message._.config.remote;
+		config.local_port  = message._.config.remote_port;
+		config.remote      = message._.config.local;
+		config.remote_port = message._.config.local_port;
+		valid              = (kportal_search(&config, true) >= 0);
+
+		/* Is the message to the current port? */
+		buffering = valid && (portal->config.remote_port != message._.config.local_port);
+
+		/* Buffering mode allocates a auxiliar buffer. */
+		if (valid && buffering)
+		{
+			while ((buf = kportal_buffer_alloc(NULL, &message._.config)) == NULL)
+			{
+				spinlock_unlock(&read_lock[portal->config.remote]);
+					/**
+					 * Release read lock to another thread consumes
+					 * buffered messages and releases buffers.
+					 **/
+				spinlock_lock(&read_lock[portal->config.remote]);
+			}
+
+			data = buf->data;
+		}
+
+		/* The message will be copied to the current buffer (if it is valid). */
+		else
+			data = buffer;
+
+		received  = 0ULL;
+
+		/* Reads. */
+		while (!message.eof)
+		{
+			/* Reads a piece of the message. */
+			if ((ret = kmailbox_read(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+				goto release;
+
+			/* Sanity check. */
+			KASSERT(!message.header);			
+
+			if (!buffering)
+			{
+				/* Isn't it ok read the message? */
+				if (!valid || ((received + message.size) > size))
+				{
+					/* Reads entire message and discart it. */
+					ret = valid ? (-EINVAL) : (0);
+					continue;
+				}
+			}
+			else
+			{
+				/* Keeps previous buffer and alloc a new one. */
+				if ((received + message.size) > MPORTAL_BUFFER_SIZE)
+				{
+					kmemcpy(data, message._.data, (MPORTAL_BUFFER_SIZE - received));
+					buf->size += (MPORTAL_BUFFER_SIZE - received);
+
+					while ((buf = kportal_buffer_alloc(buf, &buf->config)) == NULL)
+					{
+						spinlock_unlock(&read_lock[portal->config.remote]);
+							/**
+							 * Release read lock to another thread consumes
+							 * buffered messages and releases buffers.
+							 **/
+						spinlock_lock(&read_lock[portal->config.remote]);
+					}
+
+					kmemcpy(
+						buf->data,
+						message._.data + (MPORTAL_BUFFER_SIZE - received),
+						message.size - (MPORTAL_BUFFER_SIZE - received)
+					);
+
+					received  = (message.size - (MPORTAL_BUFFER_SIZE - received));
+					buf->size = received;
+					data      = (buf->data + received);
+					continue;
+				}
+
+				buf->size += message.size;
+			}
+
+			kmemcpy(data, message._.data, message.size);
+
+			/* Next pieces. */
+			data      += message.size;
+			received  += message.size;
+		}
+
+		ret = (ret >= 0) ? ((ssize_t) size) : (ret);
+
+release:
+		resource_set_notbusy(&read_channels[portal->config.remote]);
+exit:
+	spinlock_unlock(&read_lock[portal->config.remote]);
+
+	if (ret >= 0)
+	{
+		if (!valid || buffering)
+			goto again;
+
+		portal->volume += size;
+	}
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_aread_local()                                                   *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_aread_local(
+	struct mportal * portal,
+	void * buffer,
+	size_t size
+)
+{
+	ssize_t ret;                      /* Return value.            */
+	size_t remainder;                 /* Remainder data size.     */
+	struct mportal_buffer * previous; /* Auxiliar buffer pointer. */
+
+	remainder = size;
+	previous  = NULL;
+
+again:
+	spinlock_lock(&local_lock);
+
+		/* Reads buffered message. */
+		if ((ret = kportal_buffer_read(portal, &buffer, &remainder, &previous)) < 0)
+			goto error;
+
+		/* Successfully readed. */
+		if (remainder == 0)
+			portal->volume += size;
+
+		/* Still reading. */
+		else if ((remainder == size) || previous)
+		{
+			spinlock_unlock(&local_lock);
+			goto again;
+		}
+
+		/* Error occurred. */
+		else
+			ret = (-EINVAL);
+
+error:
+	spinlock_unlock(&local_lock);
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_aread()                                                            *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The kportal_aread() asynchronously read @p size bytes of
+ * data pointed to by @p buffer from the input portal @p portalid.
+ */
+PUBLIC ssize_t kportal_aread(int portalid, void * buffer, size_t size)
+{
+	ssize_t ret;      /* Return value. */
+	uint64_t latency; /* Latency.      */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
+	/* Invalid size. */
+	if (size == 0 || size > KPORTAL_MAX_SIZE)
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EACCES);
+
+		/* Bad sync. */
+		if (mportals[portalid].config.remote == -1)
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		resource_set_busy(&mportals[portalid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	/* Is local communication? */
+	if (node_is_local(mportals[portalid].config.remote))
+		ret = do_kportal_aread_local(&mportals[portalid], buffer, size);
+	else
+	{
+		ret = do_kportal_aread(&mportals[portalid], buffer, size);
+
+		if (ret >= 0)
+		{
+			kmailbox_ioctl(mportals[portalid].mdata, MAILBOX_IOCTL_GET_LATENCY, &latency);
+			mportals[portalid].latency += latency;
+		}
+	}
+
+	spinlock_lock(&global_lock);
+		/* Complete the communication allowed. */
+		mportals[portalid].mallow             = -1;
+		mportals[portalid].mdata              = -1;
+		mportals[portalid].config.remote      = -1;
+		mportals[portalid].config.remote_port = -1;
+
+		resource_set_notbusy(&mportals[portalid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_awrite()                                                           *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * kportal_receive_allow()                                                    *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE void kportal_receive_allow(struct mportal_config * config)
+{
+	/* Sanity checks. */
+	KASSERT(node_is_local(config->remote));
+
+	for (unsigned i = 0; i < KPORTAL_MAX; ++i)
+	{
+		if (!resource_is_used(&mportals[i].resource))
+			continue;
+
+		if (!resource_is_writable(&mportals[i].resource))
+			continue;
+
+		if (mportals[i].config.remote != config->local)
+			continue;
+
+		if (remote_is_allowed[config->local])
+			kportal_print_message("Drop allow (double allowed)", config);
+		else
+			remote_is_allowed[config->local] = true;
+
+		break;
+	}
+
+	if (!remote_is_allowed[config->local])
+		kportal_print_message("Drop allow (any portal opened to remote)", config);
+}
+
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_wait_allow()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int do_kportal_wait_allow(struct mportal * portal)
+{
+	int ret;
+	bool released;
+	struct mportal_config config; /* Hash buffer. */
+
+	released = false;
+
+	while (!released)
+	{
+		spinlock_lock(&allow_lock);
+
+			/* Released. */
+			if (!remote_is_allowed[portal->config.remote])
+			{
+				ret = (-EAGAIN);
+
+				/* Waits allow message. */
+				if ((ret = kmailbox_read(portal->mallow, &config, MPORTAL_CONFIG_SIZE)) < 0)
+				{
+					spinlock_unlock(&allow_lock);
+					return (ret);
+				}
+
+				/* Allow remote communication. */
+				kportal_receive_allow(&config);
+			}
+
+			/* Released. */
+			if (remote_is_allowed[portal->config.remote])
+			{
+				released = true;
+				remote_is_allowed[portal->config.remote] = false;
+			}
+
+		spinlock_unlock(&allow_lock);
+	}
+
+	return (0);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_awrite()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_awrite(struct mportal * portal, const void * buffer, size_t size)
+{
+	ssize_t ret;                    /* Return value.               */
+	size_t n;                       /* Size of current data piece. */
+	size_t sended;                  /* Amount of data sended.      */
+	size_t remainder;               /* Remainder of total data.    */
+	size_t times;                   /* Number of pieces.           */
+	struct mportal_message message; /* Message buffer.             */
+
+	/* Waits allows. */
+	if ((ret = do_kportal_wait_allow(portal)) < 0)
+		return (ret);
+
+	/* Sends header. */
+	message.header   = true;
+	message.eof      = false;
+	message._.config = portal->config;
+
+again:
+	spinlock_lock(&write_lock[portal->config.remote]);
+
+		if (resource_is_busy(&write_channels[portal->config.remote]))
+		{
+			spinlock_unlock(&write_lock[portal->config.remote]);
+			goto again;
+		}
+
+		resource_set_busy(&write_channels[portal->config.remote]);
+
+		/* Reads a piece of the message. */
+		if ((ret = kmailbox_write(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+			goto error;
+
+		/* Sends data. */
+		sended    = 0ULL;
+		times     = size / MPORTAL_MESSAGE_DATA_SIZE;
+		remainder = size - (times * MPORTAL_MESSAGE_DATA_SIZE);
+
+		message.header = false;
+		message.eof    = false;
+
+		for (size_t t = 0; t < times + (remainder != 0); ++t)
+		{
+			n = (t != times) ? MPORTAL_MESSAGE_DATA_SIZE : remainder;
+
+			kmemcpy(message._.data, buffer, n);
+
+			sended      += (message.size = n);
+			message.eof  = (sended == size);
+
+			/* Reads a piece of the message. */
+			if ((ret = kmailbox_write(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+				goto error;
+
+			/* Next pieces. */
+			buffer += n;
+		}
+
+		ret = size;
+
+error:
+		resource_set_notbusy(&write_channels[portal->config.remote]);
+	spinlock_unlock(&write_lock[portal->config.remote]);
+
+	if (ret >= 0)
+		portal->volume += size;
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_awrite_local()                                                  *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_awrite_local(struct mportal * portal, const void * buffer, size_t size)
+{
+	size_t n;                    /* Size of current data piece. */
+	uint64_t t0;                 /* Clock value.                */
+	uint64_t t1;                 /* Clock value.                */
+	size_t remainder;            /* Remainder of total data.    */
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer.    */
+	struct mportal_buffer * aux; /* Auxiliar buffer pointer.    */
+
+	buf       = NULL;
+	remainder = size;
+
+again:
+	spinlock_lock(&local_lock);
+
+		while (remainder)
+		{
+			n = (remainder < MPORTAL_BUFFER_SIZE) ? remainder : MPORTAL_BUFFER_SIZE;
+
+			/* Has any buffer free? */
+			if ((aux = kportal_buffer_alloc(buf, &portal->config)) != NULL)
+				buf = aux;
+			else
+			{
+				spinlock_unlock(&local_lock);
+				goto again;
+			}
+
+			kclock(&t0);
+				kmemcpy(buf->data, buffer, n);
+			kclock(&t1);
+			portal->latency += (t1 - t0);
+
+			remainder -= n;
+			buffer    += n;
+			buf->size += n;
+		}
+
+	spinlock_unlock(&local_lock);
+
+	portal->volume += size;
+
+	return (size);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_awrite()                                                           *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The kportal_awrite() asynchronously write @p size bytes
+ * of data pointed to by @p buffer to the output portal @p portalid.
+ */
+PUBLIC ssize_t kportal_awrite(int portalid, const void * buffer, size_t size)
+{
+	ssize_t ret;      /* Return value. */
+	uint64_t latency; /* Latency.      */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
+	/* Invalid size. */
+	if (size == 0 || size > KPORTAL_MAX_SIZE)
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_writable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		resource_set_busy(&mportals[portalid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	/* Is local communication? */
+	if (node_is_local(mportals[portalid].config.remote))
+		ret = do_kportal_awrite_local(&mportals[portalid], buffer, size);
+	else
+	{
+		ret = do_kportal_awrite(&mportals[portalid], buffer, size);
+
+		if (ret >= 0)
+		{
+			kmailbox_ioctl(mportals[portalid].mdata, MAILBOX_IOCTL_GET_LATENCY, &latency);
+			mportals[portalid].latency += latency;
+		}
+	}
+
+	spinlock_lock(&global_lock);
+		resource_set_notbusy(&mportals[portalid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_wait()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_wait() waits for asyncrhonous operations in
+ * the input/output portal @p portalid to complete.
+ */
+PUBLIC int kportal_wait(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_read()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_read() synchronously read @p size bytes of
+ * data pointed to by @p buffer from the input portal @p portalid.
+ */
+PUBLIC ssize_t kportal_read(int portalid, void * buffer, size_t size)
+{
+	return (kportal_aread(portalid, buffer, size));
+}
+
+/*============================================================================*
+ * kportal_write()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_write() synchronously write @p size bytes of
+ * data pointed to by @p buffer to the output portal @p portalid.
+ */
+PUBLIC ssize_t kportal_write(int portalid, const void * buffer, size_t size)
+{
+	return (kportal_awrite(portalid, buffer, size));
+}
+
+/*============================================================================*
+ * kportal_ioctl()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_ioctl() reads the measurement parameter associated
+ * with the request id @p request of the portal @p portalid.
+ */
+PUBLIC int kportal_ioctl(int portalid, unsigned request, ...)
+{
+	int ret;      /* Return value.  */
+	va_list args; /* Argument list. */
+
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		ret = 0;
+
+		va_start(args, request);
+
+		/* Parse request. */
+		switch (request)
+		{
+			/* Get the amount of data transferred so far. */
+			case KPORTAL_IOCTL_GET_VOLUME:
+			{
+				size_t *volume;
+				volume = va_arg(args, size_t *);
+				*volume = mportals[portalid].volume;
+			} break;
+
+			/* Get the cumulative transfer latency. */
+			case KPORTAL_IOCTL_GET_LATENCY:
+			{
+				uint64_t *latency;
+				latency = va_arg(args, uint64_t *);
+				*latency = mportals[portalid].latency;
+			} break;
+
+			/* Operation not supported. */
+			default:
+				ret = (-ENOTSUP);
+				break;
+		}
+
+		va_end(args);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+
+/*============================================================================*
+ * kportal_write()                                                            *
+ *============================================================================*/
+
+/**
+ * @details Write details.
+ */
+PUBLIC int kportal_get_port(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		ret = mportals[portalid].config.local_port;
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_init()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_init() Initializes underlying mailboxes.
+ */
+PUBLIC void kportal_init(void)
+{
+	unsigned local = knode_get_num();
+
+	kprintf("[user][portal] Initializes portal module (mailbox implementation)");
+
+	/* Create input mailbox. */
+	KASSERT(
+		(mallow_in = kcall2(
+			NR_mailbox_create,
+			(word_t) local,
+			(word_t) (MAILBOX_PORT_NR - 2)
+		)) >= 0
+	);
+
+	/* Opens output mailboxes. */
+	for (unsigned i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
+	{
+		if (i == local)
+			continue;
+
+		KASSERT(
+			(mallow_outs[i] = kcall2(
+				NR_mailbox_open,
+				(word_t) i,
+				(word_t) (MAILBOX_PORT_NR - 2)
+			)) >= 0
+		);
+
+		KASSERT(
+			(mdata_ins[i] = kcall2(
+				NR_mailbox_create,
+				(word_t) local,
+				(word_t) (MAILBOX_PORT_NR - 3 - i)
+			)) >= 0
+		);
+
+		KASSERT(
+			(mdata_outs[i] = kcall2(
+				NR_mailbox_open,
+				(word_t) i,
+				(word_t) (MAILBOX_PORT_NR - 3 - local)
+			)) >= 0
+		);
+
+		/* Set channel busy. */
+		resource_set_used(&read_channels[i]);
+	}
+
+	kportal_is_initialized = true;
+}
+
+#else
+extern int make_iso_compilers_happy;
+#endif /* __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/libnanvix/ikc/msync.c
+++ b/src/libnanvix/ikc/msync.c
@@ -1,0 +1,679 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define __NEED_RESOURCE
+
+#include <nanvix/kernel/kernel.h>
+
+#if __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX
+
+#include <nanvix/sys/noc.h>
+#include <nanvix/sys/mailbox.h>
+#include <posix/errno.h>
+
+/**
+ * @brief Indicates if ksync_init is called.
+ */
+PRIVATE bool ksync_is_initialized = false;
+
+/**
+ * @name Protections.
+ */
+/**@{*/
+PRIVATE spinlock_t global_lock = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t wait_lock   = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t signal_lock = SPINLOCK_UNLOCKED;
+/**@}*/
+
+/**
+ * @name Mailbox channels.
+ */
+/**@{*/
+PRIVATE int inbox = -1;
+PRIVATE int outboxes[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+/**@}*/
+
+/*============================================================================*
+ * Sync hash                                                                  *
+ *============================================================================*/
+
+/**
+ * @name Hash macros.
+ */
+/**@{*/
+#define MSYNC_HASH_SIZE (sizeof(struct msync_hash))
+#define MSYNC_HASH_NULL ((struct msync_hash){-1, 0, -1, 0, 0, 0})
+/**@}*/
+
+/**
+ * @brief Hash structure.
+ */
+struct msync_hash
+{
+	uint64_t source    :  5; /**< Source nodenum.   */
+	uint64_t type      :  1; /**< Type of the sync. */
+	uint64_t master    :  5; /**< Master nodenum.   */
+	uint64_t nodeslist : 20; /**< Nodes list.       */
+	uint64_t barrier   : 20; /**< Barrier variable. */
+	uint64_t unused    : 13; /**< Unused.           */
+};
+
+/*============================================================================*
+ * Sync Structures.                                                           *
+ *============================================================================*/
+
+/**
+ * @brief Table of active synchronization points.
+ */
+PRIVATE struct msync
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource; /**< Generic resource information. */
+	int refcount;             /**< Counter of references.        */
+	int nbarriers;            /**< Counter of barriers.          */
+	struct msync_hash hash;   /**< Sync hash.                    */
+} ALIGN(sizeof(dword_t)) msyncs[(SYNC_CREATE_MAX + SYNC_OPEN_MAX)] = {
+	[0 ... (SYNC_CREATE_MAX + SYNC_OPEN_MAX - 1)] = {
+		.resource  = RESOURCE_INITIALIZER,
+		.refcount  = 0,
+		.nbarriers = 0,
+		.hash      = MSYNC_HASH_NULL,
+	},
+};
+
+/**
+ * @brief Resource pool.
+ */
+PRIVATE const struct resource_pool msyncpool = {
+	msyncs, (SYNC_CREATE_MAX + SYNC_OPEN_MAX), sizeof(struct msync)
+};
+
+/*============================================================================*
+ * ksync_build_nodeslist()                                                    *
+ *============================================================================*/
+
+PRIVATE int ksync_build_nodeslist(const int * nodes, int nnodes)
+{
+	int nodeslist = 0; /* Bit-stream of nodes. */
+
+	for (int j = 0; j < nnodes; j++)
+		nodeslist |= (1ULL << nodes[j]);
+
+	return (nodeslist);
+}
+
+/*============================================================================*
+ * ksync_search()                                                             *
+ *============================================================================*/
+
+PRIVATE int ksync_search(struct msync_hash * hash, int input)
+{
+	for (unsigned i = 0; i < (SYNC_CREATE_MAX + SYNC_OPEN_MAX); ++i)
+	{
+		if (!resource_is_used(&msyncs[i].resource))
+			continue;
+
+		if (input)
+		{
+			if (!resource_is_readable(&msyncs[i].resource))
+				continue;
+		}
+
+		/* Output. */
+		else if (!resource_is_writable(&msyncs[i].resource))
+			continue;
+
+		if (msyncs[i].hash.type != hash->type)
+			continue;
+
+		if (msyncs[i].hash.master != hash->master)
+			continue;
+
+		if (msyncs[i].hash.nodeslist != hash->nodeslist)
+			continue;
+
+		return (i);
+	}
+
+	return (-EINVAL);
+}
+
+/*============================================================================*
+ * ksync_nodelist_is_valid()                                                  *
+ *============================================================================*/
+
+/**
+ * @brief Node list validation.
+ *
+ * @param local  Logic ID of local node.
+ * @param nodes  IDs of target NoC nodes.
+ * @param nnodes Number of target NoC nodes.
+ *
+ * @return Non zero if node list is valid and zero otherwise.
+ */
+PRIVATE int ksync_nodelist_is_valid(const int * nodes, int nnodes, int is_the_one)
+{
+	int local;       /* Local node.          */
+	uint64_t checks; /* Bit-stream of nodes. */
+
+	checks = 0ULL;
+	local  = knode_get_num();
+
+	/* Is the local the one? */
+	if (is_the_one && (nodes[0] != local))
+		return (0);
+
+	/* Isn't the local the one? */
+	if (!is_the_one && (nodes[0] == local))
+		return (0);
+
+	/* Build nodelist. */
+	for (int i = 0; i < nnodes; ++i)
+	{
+		/* Invalid node. */
+		if (!WITHIN(nodes[i], 0, PROCESSOR_NOC_NODES_NUM))
+			return (0);
+
+		/* Does a node appear twice? */
+		if (checks & (1ULL << nodes[i]))
+			return (0);
+
+		checks |= (1ULL << nodes[i]);
+	}
+
+	/* Is the local node founded? */
+	return (checks & (1ULL << local));
+}
+
+/*============================================================================*
+ * ksync_create()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The ksync_create() function creates an input sync
+ * and attaches it to the list NoC node @p nodes.
+ */
+PRIVATE int do_ksync_alloc(const int * nodes, int nnodes, int type, int input)
+{
+	int syncid;             /* Synchronization point.            */
+	int is_the_one;         /* Indicates rule of the local node. */
+	struct msync_hash hash; /* Sync hash.                        */
+
+	KASSERT(ksync_is_initialized);
+
+	/* Invalid nodes list. */
+	if (nodes == NULL)
+		return (-EINVAL);
+
+	/* Invalid number of nodes. */
+	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
+		return(-EINVAL);
+
+	/* Invalid sync type. */
+	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
+		return (-EINVAL);
+
+	is_the_one = input ? (type == SYNC_ALL_TO_ONE) : (type == SYNC_ONE_TO_ALL);
+
+	/* Invalid nodes list. */
+	if (!ksync_nodelist_is_valid(nodes, nnodes, is_the_one))
+		return (-EINVAL);
+
+	hash.source    = knode_get_num();
+	hash.type      = type;
+	hash.master    = nodes[0];
+	hash.nodeslist = ksync_build_nodeslist(nodes, nnodes);
+
+	if (input)
+		hash.barrier = 0;
+	else
+	{
+		/* Who should it sent to? */
+		hash.barrier = (type == SYNC_ONE_TO_ALL)   ?
+			(hash.nodeslist & ~(1 << hash.master)) : /**< Master notifies All. */
+			(hash.nodeslist & (1 << hash.master));   /**< All notify Master.   */
+	}
+
+	spinlock_lock(&global_lock);
+
+		/* Previous alloc. */
+		if ((syncid = ksync_search(&hash, input)) >= 0)
+			msyncs[syncid].refcount++;
+
+		/* First alloc. */
+		else
+		{
+			/* Allocate a msync point. */
+			if ((syncid = resource_alloc(&msyncpool)) >= 0)
+			{
+				msyncs[syncid].refcount  = 1;
+				msyncs[syncid].nbarriers = 0;
+				msyncs[syncid].hash      = hash;
+				if (input)
+					resource_set_rdonly(&msyncs[syncid].resource);
+				else
+					resource_set_wronly(&msyncs[syncid].resource);
+			}
+		}
+
+	spinlock_unlock(&global_lock);
+
+	return (syncid);
+}
+/*============================================================================*
+ * ksync_create()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The ksync_create() function creates an input sync
+ * and attaches it to the list NoC node @p nodes.
+ */
+PUBLIC int ksync_create(const int * nodes, int nnodes, int type)
+{
+	return (do_ksync_alloc(nodes, nnodes, type, true));
+}
+
+/*============================================================================*
+ * ksync_open()                                                               *
+ *============================================================================*/
+
+/**
+ * @details The ksync_open() function opens an output sync to the
+ * NoC node list @p nodes.
+ */
+PUBLIC int ksync_open(const int * nodes, int nnodes, int type)
+{
+	return (do_ksync_alloc(nodes, nnodes, type, false));
+}
+
+/*============================================================================*
+ * do_ksync_release()                                                         *
+ *============================================================================*/
+
+/**
+ * @details The do_ksync_release() function release @p syncid.
+ */
+PRIVATE int do_ksync_release(int syncid, int input)
+{
+	int ret; /* Return value. */
+
+	/* Invalid syncid. */
+	if (!WITHIN(syncid, 0, SYNC_CREATE_MAX + SYNC_OPEN_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		if (!resource_is_used(&msyncs[syncid].resource))
+			goto error;
+
+		if (input)
+		{
+			if (!resource_is_readable(&msyncs[syncid].resource))
+				goto error;
+		}
+
+		/* Output. */
+		else if (!resource_is_writable(&msyncs[syncid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		if (resource_is_busy(&msyncs[syncid].resource))
+			goto error;
+
+		/* Decrement references. */
+		msyncs[syncid].refcount--;
+
+		if (!msyncs[syncid].refcount)
+		{
+			resource_free(&msyncpool, syncid);
+			msyncs[syncid].hash = MSYNC_HASH_NULL;
+		}
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * ksync_unlink()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The ksync_unlink() function removes and releases the underlying
+ * resources associated to the input sync @p syncid.
+ */
+PUBLIC int ksync_unlink(int syncid)
+{
+	return (do_ksync_release(syncid, true));
+}
+
+/*============================================================================*
+ * ksync_wait()                                                               *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * ksync_close()                                                              *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The ksync_close() function closes and releases the
+ * underlying resources associated to the output sync @p syncid.
+ */
+PUBLIC int ksync_close(int syncid)
+{
+	return (do_ksync_release(syncid, false));
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_ignore_signal()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE void ksync_ignore_signal(char * message, struct msync_hash * hash)
+{
+	int source    = hash->source;
+	int type      = hash->type;
+	int master    = hash->master;
+	int nodeslist = hash->nodeslist;
+
+	kprintf("[sync] %s (source:%d, type:%d, master:%d, nodeslist:%d)",
+		message,
+		source,
+		type,
+		master,
+		nodeslist
+	);
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_barrier_is_complete()                                                *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int ksync_barrier_is_complete(struct msync * rx)
+{
+	int received; /* Received signals. */
+	int expected; /* Expected signals. */
+
+	received = rx->hash.barrier;
+
+	/* Does master notifies it? */
+	if (rx->hash.type == SYNC_ONE_TO_ALL)
+		expected = (rx->hash.nodeslist & (1 << rx->hash.master));
+
+	/* Does slaves notifies it? */
+	else
+		expected = (rx->hash.nodeslist & ~(1 << rx->hash.master));
+
+	return (received == expected);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_ksync_wait()                                                            *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int do_ksync_wait(struct msync * sync)
+{
+	int syncid;             /* Synchronization point. */
+	struct msync_hash hash; /* Hash buffer.           */
+
+	spinlock_lock(&global_lock);
+		/* Complete a synchronization. */
+		if (sync->nbarriers)
+		{
+			sync->nbarriers--;
+			spinlock_unlock(&global_lock);
+
+			/* Success. */
+			return (0);
+		}
+	spinlock_unlock(&global_lock);
+
+	spinlock_lock(&wait_lock);
+
+		spinlock_lock(&global_lock);
+			/* Did the last message release me? */
+			if (sync->nbarriers)
+				goto release;
+		spinlock_unlock(&global_lock);
+
+		if (kmailbox_read(inbox, &hash, MSYNC_HASH_SIZE) != MSYNC_HASH_SIZE)
+		{
+			spinlock_unlock(&wait_lock);
+			return (-EAGAIN);
+		}
+
+		spinlock_lock(&global_lock);
+
+			if ((syncid = ksync_search(&hash, true)) < 0)
+			{
+				ksync_ignore_signal("Drop signal", &hash);
+				goto release;
+			}
+
+			if (msyncs[syncid].hash.barrier & (1 << hash.source))
+			{
+				ksync_ignore_signal("Double signal", &hash);
+				goto release;
+			}
+
+			msyncs[syncid].hash.barrier |= (1 << hash.source);
+
+			if (ksync_barrier_is_complete(&msyncs[syncid]))
+			{
+				msyncs[syncid].hash.barrier = 0;
+				msyncs[syncid].nbarriers++;
+			}
+
+release:
+		spinlock_unlock(&global_lock);
+	spinlock_unlock(&wait_lock);
+
+	/* Do again. */
+	return (1);
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_wait()                                                               *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The ksync_wait() waits incomming signal on a input sync @p syncid.
+ */
+PUBLIC int ksync_wait(int syncid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid syncid. */
+	if (!WITHIN(syncid, 0, SYNC_CREATE_MAX + SYNC_OPEN_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&msyncs[syncid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&msyncs[syncid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&msyncs[syncid].resource))
+			goto error;
+
+		resource_set_busy(&msyncs[syncid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	while ((ret = do_ksync_wait(&msyncs[syncid])) > 0);
+
+	spinlock_lock(&global_lock);
+		resource_set_notbusy(&msyncs[syncid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * ksync_signal()                                                             *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * do_ksync_signal()                                                          *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int do_ksync_signal(int syncid)
+{
+	int ret; /* Return value. */
+
+	ret = (-EINVAL);
+
+	spinlock_lock(&signal_lock);
+
+		/* Sends a signal to each target node. */
+		for (unsigned target = 0; target < PROCESSOR_NOC_NODES_NUM; ++target)
+		{
+			/* Is the target valid? */
+			if (msyncs[syncid].hash.barrier & (1 << target))
+			{
+				ret = kmailbox_write(
+					outboxes[target],
+					&msyncs[syncid].hash,
+					MSYNC_HASH_SIZE
+				);
+
+				/* Error occurred? */
+				if (ret != MSYNC_HASH_SIZE)
+					break;
+			}
+		}
+
+	spinlock_unlock(&signal_lock);
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_signal()                                                             *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The ksync_signal() emmit a signal from a output sync @p syncid.
+ */
+PUBLIC int ksync_signal(int syncid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid syncid. */
+	if (!WITHIN(syncid, 0, SYNC_CREATE_MAX + SYNC_OPEN_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&msyncs[syncid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_writable(&msyncs[syncid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&msyncs[syncid].resource))
+			goto error;
+
+		resource_set_busy(&msyncs[syncid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	ret = do_ksync_signal(syncid);
+
+	spinlock_lock(&global_lock);
+		resource_set_notbusy(&msyncs[syncid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret < 0) ? (ret) : (0);
+}
+
+/*============================================================================*
+ * ksync_init()                                                               *
+ *============================================================================*/
+
+/**
+ * @details The ksync_init() Initializes underlying mailboxes.
+ */
+PUBLIC void ksync_init(void)
+{
+	int local; /* Local nodenum. */
+
+	kprintf("[user][sync] Initializes sync module (mailbox implementation)");
+
+	local = knode_get_num();
+
+	/* Create input mailbox. */
+	KASSERT(
+		(inbox = kcall2(
+			NR_mailbox_create,
+			(word_t) local,
+			(word_t) (MAILBOX_PORT_NR - 1)
+		)) >= 0
+	);
+
+	/* Opens output mailboxes. */
+	for (unsigned i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
+	{
+		KASSERT(
+			(outboxes[i] = kcall2(
+				NR_mailbox_open,
+				(word_t) i,
+				(word_t) (MAILBOX_PORT_NR - 1)
+			)) >= 0
+		);
+	}
+
+	ksync_is_initialized = true;
+}
+
+#else
+extern int make_iso_compilers_happy;
+#endif /* __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/libnanvix/ikc/noc.c
+++ b/src/libnanvix/ikc/noc.c
@@ -23,6 +23,9 @@
  */
 
 #include <nanvix/kernel/kernel.h>
+#include <nanvix/sys/mailbox.h>
+#include <nanvix/sys/portal.h>
+#include <nanvix/sys/sync.h>
 #include <posix/errno.h>
 
 /*============================================================================*
@@ -85,4 +88,28 @@ int kcomm_get_port(int id, int type)
 	);
 
 	return (ret);
+}
+
+/*============================================================================*
+ * knoc_init()                                                                *
+ *============================================================================*/
+
+/**
+ * @details The knoc_init() Initializes underlying noc systems.
+ */
+PUBLIC void knoc_init(void)
+{
+    kprintf("[user][noc] initializing the noc system");
+
+	#if __TARGET_HAS_PORTAL
+		kportal_init();
+	#endif
+
+	#if __TARGET_HAS_SYNC
+		ksync_init();
+	#endif
+
+	#if __TARGET_HAS_MAILBOX
+		kmailbox_init();
+	#endif
 }

--- a/src/libnanvix/ikc/noc.c
+++ b/src/libnanvix/ikc/noc.c
@@ -81,6 +81,11 @@ int kcomm_get_port(int id, int type)
 	if ((type != COMM_TYPE_MAILBOX) && (type != COMM_TYPE_PORTAL))
 		return (-EINVAL);
 
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	if (type == COMM_TYPE_PORTAL)
+		return (kportal_get_port(id));
+#endif
+
 	ret = kcall2(
 		NR_comm_get_port,
 		(word_t) id,
@@ -101,11 +106,11 @@ PUBLIC void knoc_init(void)
 {
     kprintf("[user][noc] initializing the noc system");
 
-	#if __TARGET_HAS_PORTAL
+	#if __TARGET_HAS_PORTAL || (__TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX)
 		kportal_init();
 	#endif
 
-	#if __TARGET_HAS_SYNC
+	#if __TARGET_HAS_SYNC || (__TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX)
 		ksync_init();
 	#endif
 

--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -181,9 +181,9 @@ int kportal_close(int portalid)
  * @details The kportal_aread() asynchronously read @p size bytes of
  * data pointed to by @p buffer from the input portal @p portalid.
  */
-int kportal_aread(int portalid, void * buffer, size_t size)
+ssize_t kportal_aread(int portalid, void * buffer, size_t size)
 {
-	int ret;
+	ssize_t ret;
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -213,9 +213,9 @@ int kportal_aread(int portalid, void * buffer, size_t size)
  * @details The kportal_awrite() asynchronously write @p size bytes
  * of data pointed to by @p buffer to the output portal @p portalid.
  */
-int kportal_awrite(int portalid, const void * buffer, size_t size)
+ssize_t kportal_awrite(int portalid, const void * buffer, size_t size)
 {
-	int ret;
+	ssize_t ret;
 
 	/* Invalid buffer. */
 	if (buffer == NULL)

--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -401,6 +401,18 @@ int kportal_ioctl(int portalid, unsigned request, ...)
 	return (ret);
 }
 
+/*============================================================================*
+ * kportal_init()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_init() Initializes portal system.
+ */
+PUBLIC void kportal_init(void)
+{
+	kprintf("[user][portal] Initializes portal module");
+}
+
 #else
 extern int make_iso_compilers_happy;
 #endif /* __TARGET_HAS_PORTAL */

--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -24,7 +24,7 @@
 
 #include <nanvix/kernel/kernel.h>
 
-#if __TARGET_HAS_PORTAL
+#if __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX
 
 #include <nanvix/sys/noc.h>
 #include <posix/errno.h>
@@ -415,4 +415,4 @@ PUBLIC void kportal_init(void)
 
 #else
 extern int make_iso_compilers_happy;
-#endif /* __TARGET_HAS_PORTAL */
+#endif /* __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/libnanvix/ikc/sync.c
+++ b/src/libnanvix/ikc/sync.c
@@ -178,6 +178,18 @@ int ksync_unlink(int syncid)
 	return (ret);
 }
 
+/*============================================================================*
+ * ksync_init()                                                               *
+ *============================================================================*/
+
+/**
+ * @details The ksync_init() Initializes sync system.
+ */
+PUBLIC void ksync_init(void)
+{
+	kprintf("[user][sync] Initializes sync module");
+}
+
 #else
 extern int make_iso_compilers_happy;
 #endif /* __TARGET_HAS_MAILBOX */

--- a/src/libnanvix/ikc/sync.c
+++ b/src/libnanvix/ikc/sync.c
@@ -24,7 +24,7 @@
 
 #include <nanvix/kernel/kernel.h>
 
-#if __TARGET_HAS_SYNC
+#if __TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX
 
 #include <nanvix/sys/noc.h>
 #include <posix/errno.h>
@@ -192,4 +192,4 @@ PUBLIC void ksync_init(void)
 
 #else
 extern int make_iso_compilers_happy;
-#endif /* __TARGET_HAS_MAILBOX */
+#endif /* __TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -214,7 +214,11 @@ static void test_api_mailbox_read_write(void)
  * API Test: Virtualization                                                   *
  *============================================================================*/
 
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+#define TEST_VIRTUALIZATION_MBX_NR KMAILBOX_PORT_NR
+#else
 #define TEST_VIRTUALIZATION_MBX_NR MAILBOX_PORT_NR
+#endif
 
 /**
  * @brief API Test: Virtualization.
@@ -248,7 +252,11 @@ static void test_api_mailbox_virtualization(void)
  * API Test: Multiplexation                                                   *
  *============================================================================*/
 
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+#define TEST_MULTIPLEXATION_MBX_PAIRS KMAILBOX_PORT_NR
+#else
 #define TEST_MULTIPLEXATION_MBX_PAIRS MAILBOX_PORT_NR
+#endif
 
 /**
  * @brief API Test: Multiplex of virtual to hardware mailboxes.
@@ -663,7 +671,12 @@ static void test_fault_mailbox_invalid_create(void)
 	test_assert(kmailbox_create(-1, 0) == -EINVAL);
 	test_assert(kmailbox_create(PROCESSOR_NOC_NODES_NUM, 0) == -EINVAL);
 	test_assert(kmailbox_create(nodenum, -1) == -EINVAL);
+
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	test_assert(kmailbox_create(nodenum, KMAILBOX_PORT_NR) == -EINVAL);
+#else
 	test_assert(kmailbox_create(nodenum, MAILBOX_PORT_NR) == -EINVAL);
+#endif
 }
 
 /*============================================================================*
@@ -774,7 +787,11 @@ static void test_fault_mailbox_invalid_open(void)
 	test_assert(kmailbox_open(-1, 0) == -EINVAL);
 	test_assert(kmailbox_open(PROCESSOR_NOC_NODES_NUM, 0) == -EINVAL);
 	test_assert(kmailbox_open(nodenum, -1) == -EINVAL);
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	test_assert(kmailbox_open(nodenum, KMAILBOX_PORT_NR) == -EINVAL);
+#else
 	test_assert(kmailbox_open(nodenum, MAILBOX_PORT_NR) == -EINVAL);
+#endif
 }
 
 /*============================================================================*

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -2264,7 +2264,7 @@ void test_portal(void)
 		{
 			portal_tests_api[i].test_fn();
 
-			// if (local == MASTER_NODENUM)
+			if (local == MASTER_NODENUM)
 				nanvix_puts(portal_tests_api[i].name);
 		}
 

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -104,6 +104,9 @@ void ___start(int argc, const char *argv[])
 	int index;
 	int nodenum;
 
+	/* Required. */
+	knoc_init();
+
 	((void) argc);
 	((void) argv);
 

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -48,8 +48,8 @@
      * @name Portal sizes.
      */
 	/**@{*/
-    #define PORTAL_SIZE       (1 * KB)                            /**< Small size. */
-	#define PORTAL_SIZE_LARGE (HAL_PORTAL_MAX_SIZE + PORTAL_SIZE) /**< Large size. */
+    #define PORTAL_SIZE       (1 * KB)                             /**< Small size. */
+	#define PORTAL_SIZE_LARGE (HAL_PORTAL_DATA_SIZE + PORTAL_SIZE) /**< Large size. */
 	/**@}*/
 
 	/**


### PR DESCRIPTION
In this PR, I introduce the implementations of Sync and Portal using mailboxes to perform the expected behavior.

By setting CFLAG `__NANVIX_IKC_USES_ONLY_MAILBOX ` to 1, you are enabling the use of this implementation. Otherwise, the default implementation will be used.

Multiplexing tests were also added with sizes larger than the buffers used.

## Related submodule PR
[[ikc] Enhancement: IKC support to allow communication only in mailboxes](https://github.com/nanvix/microkernel/pull/256)

