### PR TITLE
[ikc] Bug fix: Unnecessary dropping of signals in the Sync module (Mailbox Implementation)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,5 +95,33 @@ jobs:
         - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
         - ssh $SERVER_NAME 'bash travis/build-libnanvix.sh --no-verbose --release'
 
+    # Tests Debug
+    - stage: "Tests Debug"
+      name: "MPPA-256"
+      if: (NOT type IN (pull_request))
+      before_script:
+        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
+        - eval "$(ssh-agent -s)"
+        - chmod 600 travis_libnanvix_rsa
+        - cp $SSH_CONFIG ~/.ssh/config
+        - ssh-add travis_libnanvix_rsa
+      script:
+        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
+        - ssh $SERVER_NAME 'bash travis/test-libnanvix.sh --no-verbose --debug'
+
+    # Tests Release
+    - stage: "Tests Release"
+      name: "MPPA-256"
+      if: (NOT type IN (pull_request))
+      before_script:
+        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
+        - eval "$(ssh-agent -s)"
+        - chmod 600 travis_libnanvix_rsa
+        - cp $SSH_CONFIG ~/.ssh/config
+        - ssh-add travis_libnanvix_rsa
+      script:
+        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
+        - ssh $SERVER_NAME 'bash travis/test-libnanvix.sh --no-verbose --release'
+
 notifications:
   slack: nanvix:31ePVjsrXynUajPUDqy6I0hp

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,18 +53,18 @@ jobs:
     - stage: "Build Debug"
       name: "OpTiMSoC"
       script: docker run -v "$(pwd):/mnt" -p 4567:4567 nanvix/ubuntu:qemu-openrisc /bin/bash -l -c "cd /mnt && export TARGET=optimsoc && make contrib && make all"
-    - stage: "Build Debug"
-      name: "MPPA-256"
-      if: (NOT type IN (pull_request))
-      before_script:
-        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
-        - eval "$(ssh-agent -s)"
-        - chmod 600 travis_libnanvix_rsa
-        - cp $SSH_CONFIG ~/.ssh/config
-        - ssh-add travis_libnanvix_rsa
-      script:
-        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
-        - ssh $SERVER_NAME 'bash travis/build-libnanvix.sh --no-verbose --debug'
+#    - stage: "Build Debug"
+#      name: "MPPA-256"
+#      if: (NOT type IN (pull_request))
+#      before_script:
+#        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
+#        - eval "$(ssh-agent -s)"
+#        - chmod 600 travis_libnanvix_rsa
+#        - cp $SSH_CONFIG ~/.ssh/config
+#        - ssh-add travis_libnanvix_rsa
+#      script:
+#        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
+#        - ssh $SERVER_NAME 'bash travis/build-libnanvix.sh --no-verbose --debug'
 
     # Build Release
     - stage: "Build Release"
@@ -82,46 +82,46 @@ jobs:
     - stage: "Build Release"
       name: "OpTiMSoC"
       script: docker run -v "$(pwd):/mnt" -p 4567:4567 nanvix/ubuntu:qemu-openrisc /bin/bash -l -c "cd /mnt && export TARGET=optimsoc && export RELEASE=true && make contrib && make all"
-    - stage: "Build Release"
-      name: "MPPA-256"
-      if: (NOT type IN (pull_request))
-      before_script:
-        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
-        - eval "$(ssh-agent -s)"
-        - chmod 600 travis_libnanvix_rsa
-        - cp $SSH_CONFIG ~/.ssh/config
-        - ssh-add travis_libnanvix_rsa
-      script:
-        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
-        - ssh $SERVER_NAME 'bash travis/build-libnanvix.sh --no-verbose --release'
+#    - stage: "Build Release"
+#      name: "MPPA-256"
+#      if: (NOT type IN (pull_request))
+#      before_script:
+#        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
+#        - eval "$(ssh-agent -s)"
+#        - chmod 600 travis_libnanvix_rsa
+#        - cp $SSH_CONFIG ~/.ssh/config
+#        - ssh-add travis_libnanvix_rsa
+#      script:
+#        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
+#        - ssh $SERVER_NAME 'bash travis/build-libnanvix.sh --no-verbose --release'
 
     # Tests Debug
-    - stage: "Tests Debug"
-      name: "MPPA-256"
-      if: (NOT type IN (pull_request))
-      before_script:
-        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
-        - eval "$(ssh-agent -s)"
-        - chmod 600 travis_libnanvix_rsa
-        - cp $SSH_CONFIG ~/.ssh/config
-        - ssh-add travis_libnanvix_rsa
-      script:
-        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
-        - ssh $SERVER_NAME 'bash travis/test-libnanvix.sh --no-verbose --debug'
+#    - stage: "Tests Debug"
+#      name: "MPPA-256"
+#      if: (NOT type IN (pull_request))
+#      before_script:
+#        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
+#        - eval "$(ssh-agent -s)"
+#        - chmod 600 travis_libnanvix_rsa
+#        - cp $SSH_CONFIG ~/.ssh/config
+#        - ssh-add travis_libnanvix_rsa
+#      script:
+#        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
+#        - ssh $SERVER_NAME 'bash travis/test-libnanvix.sh --no-verbose --debug'
 
     # Tests Release
-    - stage: "Tests Release"
-      name: "MPPA-256"
-      if: (NOT type IN (pull_request))
-      before_script:
-        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
-        - eval "$(ssh-agent -s)"
-        - chmod 600 travis_libnanvix_rsa
-        - cp $SSH_CONFIG ~/.ssh/config
-        - ssh-add travis_libnanvix_rsa
-      script:
-        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
-        - ssh $SERVER_NAME 'bash travis/test-libnanvix.sh --no-verbose --release'
+#    - stage: "Tests Release"
+#      name: "MPPA-256"
+#      if: (NOT type IN (pull_request))
+#      before_script:
+#        - openssl aes-256-cbc -K $encrypted_e8bd1388d9a0_key -iv $encrypted_e8bd1388d9a0_iv -in $SSH_KEY -out travis_libnanvix_rsa -d
+#        - eval "$(ssh-agent -s)"
+#        - chmod 600 travis_libnanvix_rsa
+#        - cp $SSH_CONFIG ~/.ssh/config
+#        - ssh-add travis_libnanvix_rsa
+#      script:
+#        - rsync -avz --delete-after --exclude=".git" . $SERVER_NAME:~/travis/libnanvix
+#        - ssh $SERVER_NAME 'bash travis/test-libnanvix.sh --no-verbose --release'
 
 notifications:
   slack: nanvix:31ePVjsrXynUajPUDqy6I0hp

--- a/build/unix64/make/makefile.cflags
+++ b/build/unix64/make/makefile.cflags
@@ -22,9 +22,210 @@
 # SOFTWARE.
 #
 
+# Switch to Level 0 Optimizations
+export CFLAGS += -O0
+
 ifeq ($(RELEASE), true)
 
-	# Switch to Level 3 Optimizations
-	export CFLAGS += -O3
+	# Level 1 Optimization Flags
+	export CFLAGS += -fauto-inc-dec
+	export CFLAGS += -fbranch-count-reg
+	export CFLAGS += -fcombine-stack-adjustments
+	export CFLAGS += -fcompare-elim
+	export CFLAGS += -fcprop-registers
+	export CFLAGS += -fdce
+	export CFLAGS += -fdefer-pop
+	# export CFLAGS += -fdelayed-branch                              # === BREAKS COMPILATION ===
+	export CFLAGS += -fdse
+	export CFLAGS += -fforward-propagate
+	export CFLAGS += -fguess-branch-probability
+	export CFLAGS += -fif-conversion
+	export CFLAGS += -fif-conversion2
+	export CFLAGS += -finline-functions-called-once
+	export CFLAGS += -fipa-profile
+	export CFLAGS += -fipa-pure-const
+	export CFLAGS += -fipa-reference
+	# export CFLAGS += -fipa-reference-addressable                   # === BREAKS COMPILATION ===
+	export CFLAGS += -fmerge-constants
+	export CFLAGS += -fmove-loop-invariants
+	export CFLAGS += -fomit-frame-pointer
+	export CFLAGS += -freorder-blocks
+	export CFLAGS += -fshrink-wrap
+	export CFLAGS += -fshrink-wrap-separate
+	export CFLAGS += -fsplit-wide-types
+	export CFLAGS += -fssa-backprop
+	export CFLAGS += -fssa-phiopt
+	export CFLAGS += -ftree-bit-ccp
+	export CFLAGS += -ftree-ccp
+	export CFLAGS += -ftree-ch
+	export CFLAGS += -ftree-coalesce-vars
+	export CFLAGS += -ftree-copy-prop
+	export CFLAGS += -ftree-dce
+	export CFLAGS += -ftree-dominator-opts
+	export CFLAGS += -ftree-dse
+	export CFLAGS += -ftree-forwprop
+	export CFLAGS += -ftree-fre
+	export CFLAGS += -ftree-phiprop
+	export CFLAGS += -ftree-pta
+	export CFLAGS += -ftree-scev-cprop
+	export CFLAGS += -ftree-sink
+	export CFLAGS += -ftree-slsr
+	export CFLAGS += -ftree-sra
+	export CFLAGS += -ftree-ter
+	export CFLAGS += -funit-at-a-time
+
+	# Level 2 Optimization Flags
+	export CFLAGS += -falign-functions -falign-jumps
+	export CFLAGS += -falign-labels -falign-loops
+	export CFLAGS += -fcaller-saves
+	export CFLAGS += -fcode-hoisting
+	export CFLAGS += -fcrossjumping
+	export CFLAGS += -fcse-follow-jumps -fcse-skip-blocks
+	export CFLAGS += -fdelete-null-pointer-checks
+	export CFLAGS += -fdevirtualize -fdevirtualize-speculatively
+	export CFLAGS += -fexpensive-optimizations
+	export CFLAGS += -fgcse -fgcse-lm
+	export CFLAGS += -fhoist-adjacent-loads
+	export CFLAGS += -finline-small-functions
+	export CFLAGS += -findirect-inlining
+	export CFLAGS += -fipa-bit-cp
+	export CFLAGS += -fipa-cp
+	export CFLAGS += -fipa-icf
+	export CFLAGS += -fipa-ra
+	export CFLAGS += -fipa-sra
+	export CFLAGS += -fipa-vrp
+	export CFLAGS += -fisolate-erroneous-paths-dereference
+	export CFLAGS += -flra-remat
+	export CFLAGS += -foptimize-sibling-calls
+	export CFLAGS += -foptimize-strlen
+	export CFLAGS += -fpartial-inlining
+	export CFLAGS += -fpeephole2
+	export CFLAGS += -freorder-blocks-algorithm=stc
+	export CFLAGS += -freorder-blocks-and-partition
+	export CFLAGS += -freorder-functions
+	export CFLAGS += -frerun-cse-after-loop
+	export CFLAGS += -fschedule-insns -fschedule-insns2
+	export CFLAGS += -fsched-interblock -fsched-spec
+	export CFLAGS += -fstore-merging
+	export CFLAGS += -fstrict-aliasing
+	export CFLAGS += -fthread-jumps
+	export CFLAGS += -ftree-builtin-call-dce
+	export CFLAGS += -ftree-pre
+	export CFLAGS += -ftree-switch-conversion -ftree-tail-merge
+	export CFLAGS += -ftree-vrp
+
+	# Level 3 Optimization Flags
+	export CFLAGS += -fgcse-after-reload
+	export CFLAGS += -finline-functions
+	export CFLAGS += -fipa-cp-clone
+	export CFLAGS += -floop-interchange
+	export CFLAGS += -floop-unroll-and-jam
+	export CFLAGS += -fpeel-loops
+	export CFLAGS += -fpredictive-commoning
+	export CFLAGS += -fsplit-paths
+	export CFLAGS += -ftree-loop-distribute-patterns
+	export CFLAGS += -ftree-loop-distribution
+	export CFLAGS += -ftree-loop-vectorize
+	export CFLAGS += -ftree-partial-pre
+	export CFLAGS += -ftree-slp-vectorize
+	export CFLAGS += -funswitch-loops
+	export CFLAGS += -fvect-cost-model
+	# export CFLAGS += -fversion-loops-for-strides                   # === BREAKS COMPILATION ===
+
+	# Extra Optimizations
+	export CFLAGS += -faggressive-loop-optimizations
+	export CFLAGS += -fasynchronous-unwind-tables
+	export CFLAGS += -fbranch-probabilities
+	export CFLAGS += -fbranch-target-load-optimize
+	export CFLAGS += -fbranch-target-load-optimize2
+	export CFLAGS += -fbtr-bb-exclusive
+	export CFLAGS += -fcommon
+	export CFLAGS += -fconserve-stack
+	export CFLAGS += -fcx-fortran-rules
+	export CFLAGS += -fcx-limited-range
+	export CFLAGS += -fdata-sections
+	export CFLAGS += -fearly-inlining
+	export CFLAGS += -fexceptions
+	export CFLAGS += -ffinite-math-only
+	export CFLAGS += -ffloat-store
+	export CFLAGS += -fforward-propagate
+	export CFLAGS += -fgcse-las
+	export CFLAGS += -fgcse-sm
+	export CFLAGS += -fpeephole
+	export CFLAGS += -fjump-tables
+	export CFLAGS += -fnon-call-exceptions
+	export CFLAGS += -fprefetch-loop-arrays
+	export CFLAGS += -freg-struct-return
+	export CFLAGS += -frename-registers
+	export CFLAGS += -freschedule-modulo-scheduled-loops
+	export CFLAGS += -frounding-math
+	export CFLAGS += -fsched-critical-path-heuristic
+	export CFLAGS += -fsched-dep-count-heuristic
+	export CFLAGS += -fsched-group-heuristic
+	export CFLAGS += -fsched-last-insn-heuristic
+	export CFLAGS += -fsched-pressure
+	export CFLAGS += -fira-hoist-pressure
+	export CFLAGS += -fira-loop-pressure
+	export CFLAGS += -fgraphite-identity
+	export CFLAGS += -floop-block
+	export CFLAGS += -floop-parallelize-all
+	export CFLAGS += -floop-strip-mine
+	export CFLAGS += -finline
+	export CFLAGS += -finline-atomics
+	export CFLAGS += -fipa-pta
+	export CFLAGS += -fisolate-erroneous-paths-attribute
+	export CFLAGS += -fivopts
+	export CFLAGS += -flifetime-dse
+	export CFLAGS += -flive-range-shrinkage
+	export CFLAGS += -floop-nest-optimize
+	export CFLAGS += -fmath-errno
+	export CFLAGS += -fmerge-all-constants
+	export CFLAGS += -fmodulo-sched
+	export CFLAGS += -fpack-struct
+	export CFLAGS += -fsched-rank-heuristic
+	export CFLAGS += -fsched-spec
+	export CFLAGS += -fsched-spec-insn-heuristic
+	export CFLAGS += -fsched-spec-load
+	export CFLAGS += -fsched-spec-load-dangerous
+	export CFLAGS += -fsched-stalled-insns
+	export CFLAGS += -fsched-stalled-insns-dep
+	export CFLAGS += -fsched2-use-superblocks
+	export CFLAGS += -fsel-sched-pipelining
+	export CFLAGS += -fsel-sched-pipelining-outer-loops
+	export CFLAGS += -fsel-sched-reschedule-pipelined
+	export CFLAGS += -fselective-scheduling
+	export CFLAGS += -fselective-scheduling2
+	export CFLAGS += -fshort-enums
+	export CFLAGS += -fshort-wchar
+	export CFLAGS += -fsignaling-nans
+	export CFLAGS += -fsigned-zeros
+	export CFLAGS += -fsingle-precision-constant
+	export CFLAGS += -fsplit-ivs-in-unroller
+	export CFLAGS += -ftoplevel-reorder
+	export CFLAGS += -ftrapping-math
+	export CFLAGS += -ftrapv
+	export CFLAGS += -ftree-coalesce-inlined-vars
+	export CFLAGS += -ftree-copyrename
+	export CFLAGS += -ftree-cselim
+	export CFLAGS += -ftree-fre
+	export CFLAGS += -ftree-loop-if-convert
+	export CFLAGS += -ftree-loop-if-convert-stores
+	export CFLAGS += -ftree-loop-im
+	export CFLAGS += -ftree-loop-ivcanon
+	export CFLAGS += -ftree-loop-optimize
+	export CFLAGS += -ftree-lrs
+	export CFLAGS += -ftree-phiprop
+	export CFLAGS += -ftree-reassoc
+	export CFLAGS += -ftree-vectorize
+	export CFLAGS += -funroll-all-loops
+	export CFLAGS += -funroll-loops
+	export CFLAGS += -funsafe-loop-optimizations
+	# export CFLAGS += -funsafe-math-optimizations                   # === BREAKS COMPILATION ===
+	export CFLAGS += -funwind-tables
+	export CFLAGS += -fvariable-expansion-in-unroller
+	export CFLAGS += -fvpt
+	export CFLAGS += -fweb
+	# export CFLAGS += -fwhole-program                               # === BREAKS COMPILATION ===
+	export CFLAGS += -fwrapv
 
 endif

--- a/include/nanvix/runtime/barrier.h
+++ b/include/nanvix/runtime/barrier.h
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_RUNTIME_BARRIER_H_
+#define NANVIX_RUNTIME_BARRIER_H_
+
+	/**
+	 * @brief Barrier
+	 */
+	typedef struct
+	{
+		int leader;   /**< Leader Node      */
+		int syncs[2]; /**< Underlying Syncs */
+	} barrier_t;
+
+	/**
+	 * @brief NULL Barrier
+	 */
+	#define BARRIER_NULL ((barrier_t) { .leader = -1, .syncs[0] = -1, .syncs[1] = -1 })
+
+	/**
+	 * @brief Asserts if a barrier is invalid.
+	 *
+	 * @param x Target barrier.
+	 */
+	#define BARRIER_IS_VALID(x) \
+		(!((barrier.leader < 0) || (barrier.syncs[0] < 0 || (barrier.syncs[1] < 0))))
+
+	/**
+	 * @brief Creates a barrier.
+	 *
+	 * @returns Upons sucessful completion a newly created barrier is
+	 * returned. Upon failure BARRIER_NULL is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	extern barrier_t barrier_create(const int *nodes, int nnodes);
+
+	/**
+	 * @brief Destroys a barrier.
+	 *
+	 * @param barrier Target barrier.
+	 *
+	 * @returns Upon sucessful completion, zero is returned. Upon failure a
+	 * negative errorcode is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	extern int barrier_destroy(barrier_t barrier);
+
+	/**
+	 * @brief Waits on a barrier.
+	 *
+	 * @param barrier Target barrier.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon failure,
+	 * a negative error code is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	extern int barrier_wait(barrier_t barrier);
+
+#endif /* NANVIX_RUNTIME_BARRIER_H_ */

--- a/include/nanvix/runtime/stdikc.h
+++ b/include/nanvix/runtime/stdikc.h
@@ -25,6 +25,11 @@
 #ifndef NANVIX_RUNTIME_STDIKC_H_
 #define NANVIX_RUNTIME_STDIKC_H_
 
+	#include <nanvix/sys/mailbox.h>
+	#include <nanvix/sys/noc.h>
+	#include <nanvix/sys/portal.h>
+	#include <nanvix/sys/sync.h>
+
 /*============================================================================*
  * Kernel Standard Synchronization Point                                      *
  *============================================================================*/

--- a/include/nanvix/runtime/stdikc.h
+++ b/include/nanvix/runtime/stdikc.h
@@ -35,13 +35,6 @@
  *============================================================================*/
 
 	/**
-	 * @brief Gets the kernel standard sync.
-	 *
-	 * @return The kernel standard sync.
-	 */
-	extern int stdsync_get(void);
-
-	/**
 	 * @brief Waits/Releases the standard kernel fence.
 	 *
 	 * @return Upon successful completion, zero is returned. Upon

--- a/include/nanvix/sys/mailbox.h
+++ b/include/nanvix/sys/mailbox.h
@@ -34,6 +34,19 @@
 	#include <posix/sys/types.h>
 
 	/**
+	 * @brief If the configuration of IKC systems is missing, then disable
+	 * the implementation that uses only mailboxes.
+	 */
+	#ifndef __NANVIX_IKC_USES_ONLY_MAILBOX
+	#define __NANVIX_IKC_USES_ONLY_MAILBOX 0
+	#endif
+
+	/**
+	 * @brief Initializes the user-side of the mailbox system.
+	 */
+	extern void kmailbox_init(void);
+
+	/**
 	 * @brief Creates an input mailbox.
 	 *
 	 * @param local Target local NoC node.

--- a/include/nanvix/sys/noc.h
+++ b/include/nanvix/sys/noc.h
@@ -39,6 +39,7 @@
 	extern int knode_get_num(void);
 	extern int kcluster_get_num(void);
 	extern int kcomm_get_port(int, int);
+	extern void knoc_init(void);
 	/**@}*/
 
 #endif /* NANVIX_SYS_NOC_H_ */

--- a/include/nanvix/sys/noc.h
+++ b/include/nanvix/sys/noc.h
@@ -38,6 +38,7 @@
 	/**@{*/
 	extern int knode_get_num(void);
 	extern int kcluster_get_num(void);
+	extern int kcomm_get_port(int, int);
 	/**@}*/
 
 #endif /* NANVIX_SYS_NOC_H_ */

--- a/include/nanvix/sys/portal.h
+++ b/include/nanvix/sys/portal.h
@@ -35,6 +35,19 @@
 	#include <posix/stdint.h>
 
 	/**
+	 * @brief If the configuration of IKC systems is missing, then disable
+	 * the implementation that uses only mailboxes.
+	 */
+	#ifndef __NANVIX_IKC_USES_ONLY_MAILBOX
+		#define __NANVIX_IKC_USES_ONLY_MAILBOX 0
+	#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
+
+	/**
+	 * @brief Initializes the user-side of the portal system.
+	 */
+	extern void kportal_init(void);
+
+	/**
 	 * @brief Creates a portal.
 	 *
 	 * @param local      Logic ID of the Local Node.
@@ -100,7 +113,7 @@
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	extern int kportal_read(int portalid, void * buffer, size_t size);
+	extern ssize_t kportal_read(int portalid, void * buffer, size_t size);
 
 	/**
 	 * @brief Asynchronously reads data from a portal.
@@ -112,7 +125,7 @@
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	extern int kportal_aread(int portalid, void * buffer, size_t size);
+	extern ssize_t kportal_aread(int portalid, void * buffer, size_t size);
 
 	/**
 	 * @brief Writes data to a portal.
@@ -124,7 +137,7 @@
 	 * @returns Upon successful, zero is returned. Upon failure, a
 	 * negative error code is returned instead.
 	 */
-	extern int kportal_write(int portalid, const void * buffer, size_t size);
+	extern ssize_t kportal_write(int portalid, const void * buffer, size_t size);
 
 	/**
 	 * @brief Asynchronously writes data to a portal.
@@ -136,7 +149,7 @@
 	 * @returns Upon successful, zero is returned. Upon failure, a
 	 * negative error code is returned instead.
 	 */
-	extern int kportal_awrite(int portalid, const void * buffer, size_t size);
+	extern ssize_t kportal_awrite(int portalid, const void * buffer, size_t size);
 
 	/**
 	 * @brief Waits for an asynchronous operation on a portal to complete.
@@ -159,6 +172,19 @@
 	 * a negative error code is returned instead.
 	 */
 	extern int kportal_ioctl(int portalid, unsigned request, ...);
+
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+
+	/**
+	 * @brief Gets local port attached to a portal.
+	 *
+	 * @param portalid Portal ID
+	 *
+	 * @returns Upon successful completion, local port attached to portalid.
+	 */
+	extern int kportal_get_port(int portalid);
+
+#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
 
 #endif /* NANVIX_SYS_PORTAL_H_ */
 

--- a/include/nanvix/sys/sync.h
+++ b/include/nanvix/sys/sync.h
@@ -33,7 +33,20 @@
 	#include <nanvix/kernel/kernel.h>
 	#include <posix/sys/types.h>
 
-		/**
+	/**
+	 * @brief If the configuration of IKC systems is missing, then disable
+	 * the implementation that uses only mailboxes.
+	 */
+	#ifndef __NANVIX_IKC_USES_ONLY_MAILBOX
+	#define __NANVIX_IKC_USES_ONLY_MAILBOX 0
+	#endif
+
+	/**
+	 * @brief Initializes the user-side of the synchronization system.
+	 */
+	extern void ksync_init(void);
+
+	/**
 	 * @brief Creates a synchronization point.
 	 *
 	 * @param nodes  Logic IDs of Target Nodes.

--- a/include/nanvix/sys/sync.h
+++ b/include/nanvix/sys/sync.h
@@ -114,6 +114,18 @@
 	 */
 	extern int ksync_signal(int syncid);
 
+	/**
+	 * @brief Performs control operations in a sync.
+	 *
+	 * @param syncid  Target sync.
+	 * @param request Request.
+	 * @param ...     Additional arguments.
+	 *
+	 * @param Upon successful completion, zero is returned. Upon failure,
+	 * a negative error code is returned instead.
+	 */
+	extern int ksync_ioctl(int syncid, unsigned request, ...);
+
 #endif /* NANVIX_SYS_SYNC_H_ */
 
 /**@}*/

--- a/makefile
+++ b/makefile
@@ -92,6 +92,9 @@ export CFLAGS += -Wno-unused-function
 export CFLAGS += -I $(INCDIR)
 export CFLAGS += -I $(ROOTDIR)/src/lwip/src/include
 
+# Enable sync and portal implementation that uses mailboxes
+export CFLAGS += -D__NANVIX_IKC_USES_ONLY_MAILBOX=0
+
 # Additional C Flags
 include $(BUILDDIR)/makefile.cflags
 

--- a/src/libnanvix/ikc/barrier.c
+++ b/src/libnanvix/ikc/barrier.c
@@ -1,0 +1,159 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/sys/sync.h>
+
+#if __TARGET_HAS_SYNC
+
+#include <nanvix/sys/thread.h>
+#include <nanvix/runtime/stdikc.h>
+#include <nanvix/runtime/barrier.h>
+
+/**
+ * The barrier_create() function creates a barrier between the nodes
+ * listed in the array pointed to by @p nodes.
+ */
+barrier_t barrier_create(const int *nodes, int nnodes)
+{
+	barrier_t barrier;
+
+	/* Invalid list of nodes. */
+	if (nodes == NULL)
+		return (BARRIER_NULL);
+
+	/* Invalid number of nodes. */
+	if (nnodes < 2)
+		return (BARRIER_NULL);
+
+	/* Leader. */
+	if (knode_get_num() == nodes[0])
+	{
+		barrier.syncs[0] = ksync_create(
+			nodes,
+			nnodes,
+			SYNC_ALL_TO_ONE
+		);
+		barrier.syncs[1] = ksync_open(
+			nodes,
+			nnodes,
+			SYNC_ONE_TO_ALL
+		);
+	}
+
+	/* Follower. */
+	else
+	{
+		barrier.syncs[0] = ksync_open(
+			nodes,
+			nnodes,
+			SYNC_ALL_TO_ONE
+		);
+		barrier.syncs[1] = ksync_create(
+			nodes,
+			nnodes,
+			SYNC_ONE_TO_ALL
+		);
+	}
+
+	barrier.leader = nodes[0];
+
+	return (barrier);
+}
+
+/**
+ * The barrier_destroy() function closes underlying resources of the
+ * barrier @p barrier.
+ */
+int barrier_destroy(barrier_t barrier)
+{
+	int ret;
+	int err;
+
+	/* Invalid barrier. */
+	if (!BARRIER_IS_VALID(barrier))
+		return (-EINVAL);
+
+	ret = 0;
+
+	/* Leader. */
+	if (knode_get_num() == barrier.leader)
+	{
+		err = ksync_unlink(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_close(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	/* Follower. */
+	else
+	{
+		err = ksync_close(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_unlink(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	return (ret);
+}
+
+/**
+ * The barrier_wait() function causes the calling peer to block
+ * until all other participants of the barrier @p barrier have reached
+ * it.
+ */
+int barrier_wait(barrier_t barrier)
+{
+	int ret;
+	int err;
+
+	/* Invalid barrier. */
+	if (!BARRIER_IS_VALID(barrier))
+		return (-EINVAL);
+
+	ret = 0;
+
+	/* Leader */
+	if (knode_get_num() == barrier.leader)
+	{
+		err = ksync_wait(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_signal(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	/* Follower. */
+	else
+	{
+		err = ksync_signal(barrier.syncs[0]);
+		ret = (err < 0) ? err : ret;
+		err = ksync_wait(barrier.syncs[1]);
+		ret = (err < 0) ? err : ret;
+	}
+
+	return (ret);
+}
+
+#else
+extern int make_iso_compilers_happy;
+#endif /* __TARGET_HAS_MAILBOX */

--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -134,7 +134,7 @@ ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
 			(word_t) buffer,
 			(word_t) KMAILBOX_MESSAGE_SIZE
 		);
-	} while ((ret == -EAGAIN) || (ret == -EBUSY));
+	} while ((ret == -ETIMEDOUT) || (ret == -EAGAIN) || (ret == -EBUSY));
 
 	return (ret);
 }

--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -40,6 +40,11 @@ int kmailbox_create(int local, int port)
 {
 	int ret;
 
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	if (!WITHIN(port, 0, KMAILBOX_PORT_NR))
+		return (-EINVAL);
+#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
+
 	ret = kcall2(
 		NR_mailbox_create,
 		(word_t) local,
@@ -60,6 +65,11 @@ int kmailbox_create(int local, int port)
 int kmailbox_open(int remote, int remote_port)
 {
 	int ret;
+
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	if (!WITHIN(remote_port, 0, KMAILBOX_PORT_NR))
+		return (-EINVAL);
+#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
 
 	ret = kcall2(
 		NR_mailbox_open,
@@ -118,7 +128,7 @@ int kmailbox_close(int mbxid)
  * @details The kmailbox_awrite() asynchronously write @p size bytes
  * of data pointed to by @p buffer to the output mailbox @p mbxid.
  */
-ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
+ssize_t kmailbox_awrite(int mbxid, const void * buffer, size_t size)
 {
 	int ret;
 
@@ -132,7 +142,7 @@ ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
 			NR_mailbox_awrite,
 			(word_t) mbxid,
 			(word_t) buffer,
-			(word_t) KMAILBOX_MESSAGE_SIZE
+			(word_t) size
 		);
 	} while ((ret == -ETIMEDOUT) || (ret == -EAGAIN) || (ret == -EBUSY));
 
@@ -147,7 +157,7 @@ ssize_t kmailbox_awrite(int mbxid, const void *buffer, size_t size)
  * @details The kmailbox_aread() asynchronously read @p size bytes of
  * data pointed to by @p buffer from the input mailbox @p mbxid.
  */
-ssize_t kmailbox_aread(int mbxid, void *buffer, size_t size)
+ssize_t kmailbox_aread(int mbxid, void * buffer, size_t size)
 {
 	int ret;
 
@@ -161,7 +171,7 @@ ssize_t kmailbox_aread(int mbxid, void *buffer, size_t size)
 			NR_mailbox_aread,
 			(word_t) mbxid,
 			(word_t) buffer,
-			(word_t) KMAILBOX_MESSAGE_SIZE
+			(word_t) size
 		);
 	} while ((ret == -ETIMEDOUT) || (ret == -EBUSY) || (ret == -ENOMSG));
 
@@ -198,10 +208,9 @@ int kmailbox_wait(int mbxid)
  *
  * @todo Uncomment kmailbox_wait() call when microkernel properly supports it.
  */
-ssize_t kmailbox_write(int mbxid, const void *buffer, size_t size)
+ssize_t kmailbox_write(int mbxid, const void * buffer, size_t size)
 {
 	int ret;
-	char buffer2[KMAILBOX_MESSAGE_SIZE];
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -211,9 +220,7 @@ ssize_t kmailbox_write(int mbxid, const void *buffer, size_t size)
 	if ((size == 0) || (size > KMAILBOX_MESSAGE_SIZE))
 		return (-EINVAL);
 
-	kmemcpy(buffer2, buffer, size);
-
-	if ((ret = kmailbox_awrite(mbxid, buffer2, KMAILBOX_MESSAGE_SIZE)) < 0)
+	if ((ret = kmailbox_awrite(mbxid, buffer, size)) < 0)
 		return (ret);
 
 	if ((ret = kmailbox_wait(mbxid)) < 0)
@@ -230,10 +237,9 @@ ssize_t kmailbox_write(int mbxid, const void *buffer, size_t size)
  * @details The kmailbox_read() synchronously read @p size bytes of
  * data pointed to by @p buffer from the input mailbox @p mbxid.
  */
-ssize_t kmailbox_read(int mbxid, void *buffer, size_t size)
+ssize_t kmailbox_read(int mbxid, void * buffer, size_t size)
 {
 	int ret;
-	char buffer2[KMAILBOX_MESSAGE_SIZE];
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -246,15 +252,13 @@ ssize_t kmailbox_read(int mbxid, void *buffer, size_t size)
 	/* Repeat while reading valid messages for another ports. */
 	do
 	{
-		if ((ret = kmailbox_aread(mbxid, buffer2, KMAILBOX_MESSAGE_SIZE)) < 0)
+		if ((ret = kmailbox_aread(mbxid, buffer, size)) < 0)
 			return (ret);
 	} while ((ret = kmailbox_wait(mbxid)) > 0);
 
 	/* Wait failed. */
 	if (ret < 0)
 		return (ret);
-
-	kmemcpy(buffer, buffer2, size);
 
 	return (size);
 }
@@ -288,6 +292,18 @@ int kmailbox_ioctl(int mbxid, unsigned request, ...)
 	va_end(args);
 
 	return (ret);
+}
+
+/*============================================================================*
+ * kmailbox_init()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kmailbox_init() Initializes mailbox system.
+ */
+PUBLIC void kmailbox_init(void)
+{
+	kprintf("[user][mailbox] Initializes mailbox module");
 }
 
 #else

--- a/src/libnanvix/ikc/mportal.c
+++ b/src/libnanvix/ikc/mportal.c
@@ -1,0 +1,1724 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define __NEED_RESOURCE
+
+#include <nanvix/kernel/kernel.h>
+
+#if __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX
+
+#include <nanvix/sys/perf.h>
+#include <nanvix/sys/noc.h>
+#include <nanvix/sys/mailbox.h>
+#include <nanvix/sys/portal.h>
+#include <posix/errno.h>
+
+/**
+ * @brief Indicates if kportal_init is called.
+ */
+PRIVATE bool kportal_is_initialized = false;
+
+/**
+ * @name Protections.
+ */
+/**@{*/
+PRIVATE spinlock_t global_lock            = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t local_lock             = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t allow_lock             = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t buffer_lock            = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t read_lock[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = SPINLOCK_UNLOCKED
+};
+PRIVATE spinlock_t write_lock[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = SPINLOCK_UNLOCKED
+};
+/**@}*/
+
+/**
+ * @name Mailbox channels.
+ */
+/**@{*/
+PRIVATE int mallow_in = -1;
+PRIVATE int mallow_outs[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+PRIVATE int mdata_ins[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+PRIVATE int mdata_outs[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+/**@}*/
+
+/**
+ * @name Fair use of read channels.
+ */
+/**@{*/
+PRIVATE struct resource read_channels[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = RESOURCE_INITIALIZER
+};
+PRIVATE struct resource write_channels[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = RESOURCE_INITIALIZER
+};
+/**@}*/
+
+/**
+ * @brief Write control.
+ */
+PRIVATE bool remote_is_allowed[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = false
+};
+
+/*============================================================================*
+ * Portal configuration                                                       *
+ *============================================================================*/
+
+/**
+ * @name Configuration macros.
+ */
+/**@{*/
+#define MPORTAL_CONFIG_SIZE (sizeof(struct mportal_config))           /**< Size of config struct. */
+#define MPORTAL_CONFIG_NULL ((struct mportal_config){-1, -1, -1, -1}) /**< Invalid configuration. */
+/**@}*/
+
+/**
+ * @brief Configuration structure.
+ */
+struct mportal_config
+{
+	int local;       /**< Local nodenum.  */
+	int local_port;  /**< Local port id.  */
+	int remote;      /**< Remote nodenum. */
+	int remote_port; /**< Remote port id. */
+};
+
+/*============================================================================*
+ * Portal structure                                                           *
+ *============================================================================*/
+
+/**
+ * @brief Table of portals.
+ */
+PRIVATE struct mportal
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource;     /**< Generic resource information.    */
+	int refcount;                 /**< Counter of references (Avoided). */
+
+	/**
+	 * @name Communication.
+	 */
+	/**@{*/
+	int mallow;                   /**< Mailbox channel to allow.        */
+	int mdata;                    /**< Mailbox channel to data.         */
+	struct mportal_config config; /**< Configuration.                   */
+	/**@}*/
+
+	/**
+	 * @name Statistics.
+	 */
+	/**@{*/
+	size_t volume;                /**< Volume.                          */
+	uint64_t latency;             /**< Latency.                         */
+	/**@}*/
+} ALIGN(sizeof(dword_t)) mportals[KPORTAL_MAX] = {
+	[0 ... (KPORTAL_MAX - 1)] = {
+		.resource  = RESOURCE_INITIALIZER,
+		.refcount  = 0,
+		.mallow    = -1,
+		.mdata     = -1,
+		.volume    = 0ULL,
+		.latency   = 0ULL,
+		.config    = MPORTAL_CONFIG_NULL,
+	},
+};
+
+/**
+ * @brief Portal pool.
+ */
+PRIVATE const struct resource_pool mportalpool = {
+	mportals, (KPORTAL_MAX), sizeof(struct mportal)
+};
+
+/*============================================================================*
+ * Portal message                                                             *
+ *============================================================================*/
+
+/**
+ * @name Portal message macros.
+ */
+/**@{*/
+#define MPORTAL_MESSAGE_SIZE      (sizeof(struct mportal_message)) /**< Size of config struct. */
+#define MPORTAL_MESSAGE_DATA_SIZE (KMAILBOX_MESSAGE_SIZE - 6)      /**< Max data size.         */
+/**@}*/
+
+/**
+ * @brief Portal message structure.
+ */
+struct mportal_message
+{
+	/**
+	 * @name Control.
+	 */
+	/**@{*/
+	char header : 1; /**< Indicates if contains the a valid config. */
+	char eof    : 1; /**< Indicates if is the last message.         */
+	char unused : 6; /**< Unused.                                   */
+	char size;       /**< Data size.                                */
+	/**@}*/
+
+	/**
+	 * @name Data.
+	 */
+	/**@{*/
+	union
+	{
+		struct mportal_config config;         /**< Configuration.   */
+		char data[MPORTAL_MESSAGE_DATA_SIZE]; /**< Data buffer.     */
+	} _;             /**< Abstract union.                           */
+	/**@}*/
+};
+
+/*============================================================================*
+ * Portal Port (TX only)                                                      *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * Structure and variables                                                    *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Portal port structure.
+ */
+PRIVATE struct mportal_port
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource; /**< Generic resource information. */
+} mports[HAL_PORTAL_OPEN_MAX][KPORTAL_PORT_NR] = {
+	[0 ... (HAL_PORTAL_OPEN_MAX - 1)] = {
+		[0 ... (KPORTAL_PORT_NR - 1)] = {
+			.resource = RESOURCE_INITIALIZER,
+		},
+	},
+};
+
+/*----------------------------------------------------------------------------*
+ * kportal_port_alloc()                                                       *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int kportal_port_alloc(int remote)
+{
+	for (unsigned i = 0; i < KPORTAL_PORT_NR; ++i)
+	{
+		if (!resource_is_used(&mports[remote][i].resource))
+		{
+			resource_set_used(&mports[remote][i].resource);
+			return (i);
+		}
+	}
+
+	return (-EBUSY);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_port_release()                                                     *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int kportal_port_release(int remote, int portid)
+{
+	KASSERT(WITHIN(portid, 0, KPORTAL_PORT_NR));
+	KASSERT(resource_is_used(&mports[remote][portid].resource));
+	resource_set_unused(&mports[remote][portid].resource);
+	return (0);
+}
+
+/*============================================================================*
+ * kportal_search()                                                           *
+ *============================================================================*/
+
+PRIVATE void kportal_print_message(char * message, struct mportal_config * config)
+{
+	kprintf("[portal] %s (local:%d, local_port:%d, remote:%d, remote_port:%d)",
+		message,
+		config->local,
+		config->local_port,
+		config->remote,
+		config->remote_port
+	);
+}
+
+/*============================================================================*
+ * Portal Buffer                                                              *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * Structures and variables                                                   *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @name Portal buffer macros.
+ */
+/**@{*/
+#define MPORTAL_BUFFER_SIZE (KPORTAL_MESSAGE_DATA_SIZE) /**< Maximum buffer size.       */
+#define MPORTAL_BUFFER_MAX  (40)                        /**< Maximum number of buffers. */
+/**@}*/
+
+/**
+ * @brief Portal buffer structure.
+ */
+PRIVATE struct mportal_buffer
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource;       /**< Generic resource information.    */
+
+	/**
+	 * @name Control.
+	 */
+	/**@{*/
+	uint64_t age;                   /**< Buffer age.                      */
+	size_t seq;                     /**< Sequence number.                 */
+	size_t size;                    /**< Valid data size.                 */
+	struct mportal_config config;   /**< Configuration                    */
+	struct mportal_buffer * next;   /**< Next buffer of the sequence.     */
+	/**@}*/
+
+	/**
+	 * @brief Data.
+	 */
+	char data[MPORTAL_BUFFER_SIZE]; /**< Data buffer.                     */
+} mbuffers[MPORTAL_BUFFER_MAX] = {
+	[0 ... (MPORTAL_BUFFER_MAX - 1)] = {
+		.resource = RESOURCE_INITIALIZER,
+		.age    = ~(0ULL),
+		.seq    = ~(0ULL),
+		.size   = 0ULL,
+		.next   = NULL,
+		.config = MPORTAL_CONFIG_NULL,
+		.data   = {0, },
+	},
+};
+
+/**
+ * @brief Age counter of the portal buffers.
+ */
+PRIVATE uint64_t mbuffer_next_age = 0ULL;
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_alloc()                                                     *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * kportal_buffer_alloc(
+	struct mportal_buffer * previous,
+	struct mportal_config * config
+)
+{
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	buf = NULL;
+
+	if (config == NULL)
+		return (NULL);
+
+	spinlock_lock(&buffer_lock);
+
+		for (size_t i = 0; i < MPORTAL_BUFFER_MAX; ++i)
+		{
+			if (resource_is_used(&mbuffers[i].resource))
+				continue;
+
+			buf = &mbuffers[i];
+
+			if (previous == NULL)
+				buf->seq = 0;
+			else
+			{
+				buf->seq = previous->seq + 1;
+				previous->next = buf;
+			}
+
+			buf->config = *config;
+			buf->size   = 0ULL;
+			buf->next   = NULL;
+			buf->age    = mbuffer_next_age++;
+			resource_set_used(&buf->resource);
+
+			break;
+		}
+
+	spinlock_unlock(&buffer_lock);
+
+	return (buf);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_buffer_release()                                                *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * do_kportal_buffer_release(struct mportal_buffer * buf)
+{
+	struct mportal_buffer * next; /* Auxiliar buffer pointer. */
+
+	if (buf == NULL)
+		return (NULL);
+
+	if (!resource_is_used(&buf->resource))
+		return (NULL);
+
+	next = buf->next;
+
+	buf->config = MPORTAL_CONFIG_NULL;
+	buf->seq    = -1;
+	buf->size   = 0ULL;
+	buf->next   = NULL;
+	buf->age    = ~(0ULL);
+	resource_set_unused(&buf->resource);
+
+	return (next);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_release()                                                   *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * kportal_buffer_release(struct mportal_buffer * buf)
+{
+	struct mportal_buffer * next; /* Auxiliar buffer pointer. */
+
+	if (buf == NULL)
+		return (NULL);
+
+	spinlock_lock(&buffer_lock);
+		next = do_kportal_buffer_release(buf);
+	spinlock_unlock(&buffer_lock);
+
+	return (next);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_buffer_search()                                                 *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * do_kportal_buffer_search(struct mportal * portal)
+{
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	if (!node_is_local(portal->config.local))
+		kportal_print_message("kportal_search failed", &portal->config);
+
+	/* Sanity checks. */
+	KASSERT(node_is_local(portal->config.local));
+
+	buf = NULL;
+
+	for (size_t i = 0; i < MPORTAL_BUFFER_MAX; ++i)
+	{
+		if (!resource_is_used(&mbuffers[i].resource))
+			continue;
+
+		if (portal->config.local != mbuffers[i].config.remote)
+			continue;
+
+		if (portal->config.local_port != mbuffers[i].config.remote_port)
+			continue;
+
+		/* Is it a read operation? */
+		if (portal->config.remote != -1)
+		{
+			if (portal->config.remote != mbuffers[i].config.local)
+				continue;
+
+			if (portal->config.remote_port != mbuffers[i].config.local_port)
+				continue;
+
+			if (mbuffers[i].seq != 0)
+				continue;
+
+			if (buf != NULL && buf->age < mbuffers[i].age)
+				continue;
+		}
+
+		buf = &mbuffers[i];
+
+		/* Is it a find the first operation? */
+		if (portal->config.remote == -1)
+			break;
+	}
+
+	return (buf);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_search()                                                    *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct mportal_buffer * kportal_buffer_search(struct mportal * portal)
+{
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	if (portal == NULL)
+		return (NULL);
+
+	spinlock_lock(&buffer_lock);
+		buf = do_kportal_buffer_search(portal);
+	spinlock_unlock(&buffer_lock);
+
+	return (buf);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_buffer_read()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t kportal_buffer_read(
+	struct mportal * portal,
+	void ** buffer,
+	size_t * remainder,
+	struct mportal_buffer ** previous
+)
+{
+	uint64_t t0;                 /* Clock value.             */
+	uint64_t t1;                 /* Clock value.             */
+	size_t copied;               /* Amount of data copied.   */
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer. */
+
+	copied = 0ULL;
+	buf    = NULL;
+
+	if (buffer == NULL || *buffer == NULL)
+		return (-EINVAL);
+
+	spinlock_lock(&buffer_lock);
+
+		buf = (*previous) ? (*previous)->next : do_kportal_buffer_search(portal);
+
+		while (buf)
+		{
+			/* Sanity check. */
+			if (buf->size > *remainder)
+			{
+				/**
+				 * Discard entire message because it lost the previous ones.
+				 * TODO: Recover the message from "copied" buffer.
+				 **/
+				if (buf->seq > 0)
+				{
+					while (do_kportal_buffer_release(buf));
+
+					if (*previous)
+					{
+						do_kportal_buffer_release(*previous);
+						*previous = NULL;
+					}
+				}
+
+				copied = (-EINVAL);
+				goto error;
+			}
+
+			/* Copy the message. */
+			kclock(&t0);
+				kmemcpy(*buffer, buf->data, buf->size);
+			kclock(&t1);
+			portal->latency += (t1 - t0);
+
+			/* Updates parameters. */
+			copied     += buf->size;
+			*buffer    += buf->size;
+			*remainder -= buf->size;
+
+			/* Updates previous buffer. */
+			*previous = (*previous) ? do_kportal_buffer_release(*previous) : buf;
+
+			/* Get next buffer. */
+			buf = (*previous)->next;
+		}
+
+		if ((*remainder == 0) && *previous)
+		{
+			do_kportal_buffer_release(*previous);
+			*previous = NULL;
+		}
+
+error:
+	spinlock_unlock(&buffer_lock);
+
+	return (copied);
+}
+
+/*============================================================================*
+ * kportal_search()                                                           *
+ *============================================================================*/
+
+PRIVATE int kportal_search(struct mportal_config * config, int input)
+{
+	if (!node_is_local(config->local))
+		kportal_print_message("kportal_search failed", config);
+
+	/* Sanity checks. */
+	KASSERT(node_is_local(config->local));
+
+	for (unsigned i = 0; i < KPORTAL_MAX; ++i)
+	{
+		if (!resource_is_used(&mportals[i].resource))
+			continue;
+
+		if (input)
+		{
+			if (!resource_is_readable(&mportals[i].resource))
+				continue;
+		}
+
+		/* Output. */
+		else if (!resource_is_writable(&mportals[i].resource))
+			continue;
+
+		if (mportals[i].config.local != config->local)
+			continue;
+
+		if (mportals[i].config.local_port != config->local_port)
+			continue;
+
+		if (!input)
+		{
+			if (mportals[i].config.remote != config->remote)
+				continue;
+
+			if (mportals[i].config.remote_port != config->remote_port)
+				continue;
+		}
+
+		return (i);
+	}
+
+	return (-EINVAL);
+}
+
+/*============================================================================*
+ * kportal_create()                                                           *
+ *============================================================================*/
+
+/**
+ * @details The kportal_create() function creates an input portal and
+ * attaches it to the local port @p local_port in the local NoC node @p
+ * local.
+ */
+PUBLIC int kportal_create(int local, int local_port)
+{
+	int portalid;                 /* Portal ID.            */
+	struct mportal_config config; /* Portal configuration. */
+
+	KASSERT(kportal_is_initialized);
+
+	/* Invalid local. */
+	if (!node_is_valid(local))
+		return (-EINVAL);
+
+	/* Invalid local number for the requesting core ID. */
+	if (!node_is_local(local))
+		return (-EINVAL);
+
+	/* Invalid portid. */
+	if (!WITHIN(local_port, 0, KPORTAL_PORT_NR))
+		return (-EINVAL);
+
+	/* Configures portal. */
+	config.local       = local;
+	config.local_port  = local_port;
+	config.remote      = -1;
+	config.remote_port = -1;
+
+	spinlock_lock(&global_lock);
+
+		/**
+		 * Previous create.
+		 * TODO: Adds mportals[portalid].refcount++ to enable multiples
+		 * creates of a same configuration.
+		 **/
+		if ((portalid = kportal_search(&config, true)) >= 0)
+			portalid = (-EBUSY);
+
+		/* First create. */
+		else if ((portalid = resource_alloc(&mportalpool)) >= 0)
+		{
+			mportals[portalid].refcount = 1;
+			mportals[portalid].volume   = 0ULL;
+			mportals[portalid].latency  = 0ULL;
+			mportals[portalid].config   = config;
+			resource_set_rdonly(&mportals[portalid].resource);
+		}
+
+	spinlock_unlock(&global_lock);
+
+	return (portalid);
+}
+
+/*============================================================================*
+ * kportal_allow()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_allow() function allow read data from a input portal
+ * associated with the NoC node @p remote.
+ */
+PUBLIC int kportal_allow(int portalid, int remote, int remote_port)
+{
+	int ret; /* Return value. */
+
+	ret = (-EINVAL);
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	/* Invalid local. */
+	if (!node_is_valid(remote))
+		return (-EINVAL);
+
+	/* Invalid portid. */
+	if (!WITHIN(remote_port, 0, KPORTAL_PORT_NR))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		/* Already allowed. */
+		if (mportals[portalid].config.remote != -1)
+			goto error;
+
+		mportals[portalid].mallow             = mallow_outs[remote];
+		mportals[portalid].mdata              = mdata_ins[remote];
+		mportals[portalid].config.remote      = remote;
+		mportals[portalid].config.remote_port = remote_port;
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_open()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_open() function opens an output portal to the remote
+ * NoC node @p remote and attaches it to the local NoC node @p local.
+ */
+PUBLIC int kportal_open(int local, int remote, int remote_port)
+{
+	int portalid;                 /* Portal ID.            */
+	int local_port;               /* Portal port.          */
+	struct mportal_config config; /* Portal configuration. */
+
+	KASSERT(kportal_is_initialized);
+
+	/* Invalid local. */
+	if (!node_is_valid(local))
+		return (-EINVAL);
+
+	/* Invalid remote. */
+	if (!node_is_valid(remote))
+		return (-EINVAL);
+
+	/* Invalid local number for the requesting core ID. */
+	if (!node_is_local(local))
+		return (-EINVAL);
+
+	/* Invalid portid. */
+	if (!WITHIN(remote_port, 0, KPORTAL_PORT_NR))
+		return (-EINVAL);
+
+	/* Configures portal. */
+	config.local       = local;
+	config.remote      = remote;
+	config.remote_port = remote_port;
+
+	spinlock_lock(&global_lock);
+
+		portalid = (-EBUSY);
+
+		/* Alloc a local port. */
+		if ((local_port = kportal_port_alloc(remote)) < 0)
+			goto error;
+
+		config.local_port  = local_port;
+
+		/**
+		 * Previous open.
+		 * TODO: Adds mportals[portalid].refcount++ to enable multiples
+		 * open of a same configuration.
+		 **/
+		if ((portalid = kportal_search(&config, false)) >= 0)
+			portalid = (-EBUSY);
+
+		/* First create. */
+		else if ((portalid = resource_alloc(&mportalpool)) >= 0)
+		{
+			mportals[portalid].mallow   = mallow_in;
+			mportals[portalid].mdata    = mdata_outs[remote];
+			mportals[portalid].refcount = 1;
+			mportals[portalid].volume   = 0;
+			mportals[portalid].latency  = 0;
+			mportals[portalid].config   = config;
+			resource_set_wronly(&mportals[portalid].resource);
+		}
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (portalid);
+}
+
+/*============================================================================*
+ * kportal_unlink()                                                           *
+ *============================================================================*/
+
+/**
+ * @details The kportal_unlink() function removes and releases the underlying
+ * resources associated to the input portal @p portalid.
+ */
+PUBLIC int kportal_unlink(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		/* Busy sync. */
+		if (kportal_buffer_search(&mportals[portalid]) != NULL)
+			goto error;
+
+		/* Decrement references. */
+		mportals[portalid].refcount--;
+
+		/* Releases resource (for now, refcount always is 0 here). */
+		if (!mportals[portalid].refcount)
+		{
+			mportals[portalid].mallow = -1;
+			mportals[portalid].mdata  = -1;
+			mportals[portalid].config = MPORTAL_CONFIG_NULL;
+			resource_free(&mportalpool, portalid);
+		}
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_close()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_close() function closes and releases the
+ * underlying resources associated to the output portal @p portalid.
+ */
+PUBLIC int kportal_close(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_writable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		/* Decrement references. */
+		mportals[portalid].refcount--;
+
+		/* Releases resource (for now, refcount always is 0 here). */
+		if (!mportals[portalid].refcount)
+		{
+			kportal_port_release(
+				mportals[portalid].config.remote,
+				mportals[portalid].config.local_port
+			);
+			mportals[portalid].mallow = -1;
+			mportals[portalid].mdata  = -1;
+			mportals[portalid].config = MPORTAL_CONFIG_NULL;
+			resource_free(&mportalpool, portalid);
+		}
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_aread()                                                            *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_aread()                                                         *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_aread(struct mportal * portal, void * buffer, size_t size)
+{
+	ssize_t ret;                    /* Return value.                           */
+	void * data;                    /* Auxiliar buffer pointer.                */
+	bool buffering;                 /* Define where the data will be store.    */
+	bool valid;                     /* Define if the messages will be ignored. */
+	size_t received;                /* Received data counter.                  */
+	struct mportal_buffer * buf;    /* Auxiliar buffer pointer.                */
+	struct mportal_message message; /* Message buffer.                         */
+	struct mportal_config config;   /* Configuration pointer.                  */
+
+	/* Valid portal. */
+	KASSERT(portal && node_is_valid(portal->config.remote));
+
+again:
+	spinlock_lock(&read_lock[portal->config.remote]);
+
+		buf       = NULL;
+		valid     = true;
+		buffering = false;
+		received  = size;
+
+		/* Reads buffered message. */
+		if ((ret = kportal_buffer_read(portal, &buffer, &received, &buf)) != 0)
+		{
+			/* Is it copied correctly? */
+			ret = (ret == ((ssize_t) size)) ? ((ssize_t) size) : (-EINVAL);
+			goto exit;
+		}
+
+		/* Is the channel busy? */
+		if (resource_is_busy(&read_channels[portal->config.remote]))
+		{
+			spinlock_unlock(&read_lock[portal->config.remote]);
+			goto again;
+		}
+
+		/* Set channel busy. */
+		resource_set_busy(&read_channels[portal->config.remote]);
+
+		/* Allows. */
+		if ((ret = kmailbox_write(portal->mallow, &portal->config, MPORTAL_CONFIG_SIZE)) < 0)
+			goto release;
+
+		/* Reads header. */
+		if ((ret = kmailbox_read(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+			goto release;
+
+		/* Sanity check. */
+		KASSERT(message.header || !message.eof);
+
+		/* Is the message to an existing portal? */
+		config.local       = message._.config.remote;
+		config.local_port  = message._.config.remote_port;
+		config.remote      = message._.config.local;
+		config.remote_port = message._.config.local_port;
+		valid              = (kportal_search(&config, true) >= 0);
+
+		/* Is the message to the current port? */
+		buffering = valid && (portal->config.remote_port != message._.config.local_port);
+
+		/* Buffering mode allocates a auxiliar buffer. */
+		if (valid && buffering)
+		{
+			while ((buf = kportal_buffer_alloc(NULL, &message._.config)) == NULL)
+			{
+				spinlock_unlock(&read_lock[portal->config.remote]);
+					/**
+					 * Release read lock to another thread consumes
+					 * buffered messages and releases buffers.
+					 **/
+				spinlock_lock(&read_lock[portal->config.remote]);
+			}
+
+			data = buf->data;
+		}
+
+		/* The message will be copied to the current buffer (if it is valid). */
+		else
+			data = buffer;
+
+		received  = 0ULL;
+
+		/* Reads. */
+		while (!message.eof)
+		{
+			/* Reads a piece of the message. */
+			if ((ret = kmailbox_read(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+				goto release;
+
+			/* Sanity check. */
+			KASSERT(!message.header);			
+
+			if (!buffering)
+			{
+				/* Isn't it ok read the message? */
+				if (!valid || ((received + message.size) > size))
+				{
+					/* Reads entire message and discart it. */
+					ret = valid ? (-EINVAL) : (0);
+					continue;
+				}
+			}
+			else
+			{
+				/* Keeps previous buffer and alloc a new one. */
+				if ((received + message.size) > MPORTAL_BUFFER_SIZE)
+				{
+					kmemcpy(data, message._.data, (MPORTAL_BUFFER_SIZE - received));
+					buf->size += (MPORTAL_BUFFER_SIZE - received);
+
+					while ((buf = kportal_buffer_alloc(buf, &buf->config)) == NULL)
+					{
+						spinlock_unlock(&read_lock[portal->config.remote]);
+							/**
+							 * Release read lock to another thread consumes
+							 * buffered messages and releases buffers.
+							 **/
+						spinlock_lock(&read_lock[portal->config.remote]);
+					}
+
+					kmemcpy(
+						buf->data,
+						message._.data + (MPORTAL_BUFFER_SIZE - received),
+						message.size - (MPORTAL_BUFFER_SIZE - received)
+					);
+
+					received  = (message.size - (MPORTAL_BUFFER_SIZE - received));
+					buf->size = received;
+					data      = (buf->data + received);
+					continue;
+				}
+
+				buf->size += message.size;
+			}
+
+			kmemcpy(data, message._.data, message.size);
+
+			/* Next pieces. */
+			data      += message.size;
+			received  += message.size;
+		}
+
+		ret = (ret >= 0) ? ((ssize_t) size) : (ret);
+
+release:
+		resource_set_notbusy(&read_channels[portal->config.remote]);
+exit:
+	spinlock_unlock(&read_lock[portal->config.remote]);
+
+	if (ret >= 0)
+	{
+		if (!valid || buffering)
+			goto again;
+
+		portal->volume += size;
+	}
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_aread_local()                                                   *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_aread_local(
+	struct mportal * portal,
+	void * buffer,
+	size_t size
+)
+{
+	ssize_t ret;                      /* Return value.            */
+	size_t remainder;                 /* Remainder data size.     */
+	struct mportal_buffer * previous; /* Auxiliar buffer pointer. */
+
+	remainder = size;
+	previous  = NULL;
+
+again:
+	spinlock_lock(&local_lock);
+
+		/* Reads buffered message. */
+		if ((ret = kportal_buffer_read(portal, &buffer, &remainder, &previous)) < 0)
+			goto error;
+
+		/* Successfully readed. */
+		if (remainder == 0)
+			portal->volume += size;
+
+		/* Still reading. */
+		else if ((remainder == size) || previous)
+		{
+			spinlock_unlock(&local_lock);
+			goto again;
+		}
+
+		/* Error occurred. */
+		else
+			ret = (-EINVAL);
+
+error:
+	spinlock_unlock(&local_lock);
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_aread()                                                            *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The kportal_aread() asynchronously read @p size bytes of
+ * data pointed to by @p buffer from the input portal @p portalid.
+ */
+PUBLIC ssize_t kportal_aread(int portalid, void * buffer, size_t size)
+{
+	ssize_t ret;      /* Return value. */
+	uint64_t latency; /* Latency.      */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
+	/* Invalid size. */
+	if (size == 0 || size > KPORTAL_MAX_SIZE)
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EACCES);
+
+		/* Bad sync. */
+		if (mportals[portalid].config.remote == -1)
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		resource_set_busy(&mportals[portalid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	/* Is local communication? */
+	if (node_is_local(mportals[portalid].config.remote))
+		ret = do_kportal_aread_local(&mportals[portalid], buffer, size);
+	else
+	{
+		ret = do_kportal_aread(&mportals[portalid], buffer, size);
+
+		if (ret >= 0)
+		{
+			kmailbox_ioctl(mportals[portalid].mdata, MAILBOX_IOCTL_GET_LATENCY, &latency);
+			mportals[portalid].latency += latency;
+		}
+	}
+
+	spinlock_lock(&global_lock);
+		/* Complete the communication allowed. */
+		mportals[portalid].mallow             = -1;
+		mportals[portalid].mdata              = -1;
+		mportals[portalid].config.remote      = -1;
+		mportals[portalid].config.remote_port = -1;
+
+		resource_set_notbusy(&mportals[portalid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_awrite()                                                           *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * kportal_receive_allow()                                                    *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE void kportal_receive_allow(struct mportal_config * config)
+{
+	/* Sanity checks. */
+	KASSERT(node_is_local(config->remote));
+
+	for (unsigned i = 0; i < KPORTAL_MAX; ++i)
+	{
+		if (!resource_is_used(&mportals[i].resource))
+			continue;
+
+		if (!resource_is_writable(&mportals[i].resource))
+			continue;
+
+		if (mportals[i].config.remote != config->local)
+			continue;
+
+		if (remote_is_allowed[config->local])
+			kportal_print_message("Drop allow (double allowed)", config);
+		else
+			remote_is_allowed[config->local] = true;
+
+		break;
+	}
+
+	if (!remote_is_allowed[config->local])
+		kportal_print_message("Drop allow (any portal opened to remote)", config);
+}
+
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_wait_allow()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int do_kportal_wait_allow(struct mportal * portal)
+{
+	int ret;
+	bool released;
+	struct mportal_config config; /* Hash buffer. */
+
+	released = false;
+
+	while (!released)
+	{
+		spinlock_lock(&allow_lock);
+
+			/* Released. */
+			if (!remote_is_allowed[portal->config.remote])
+			{
+				ret = (-EAGAIN);
+
+				/* Waits allow message. */
+				if ((ret = kmailbox_read(portal->mallow, &config, MPORTAL_CONFIG_SIZE)) < 0)
+				{
+					spinlock_unlock(&allow_lock);
+					return (ret);
+				}
+
+				/* Allow remote communication. */
+				kportal_receive_allow(&config);
+			}
+
+			/* Released. */
+			if (remote_is_allowed[portal->config.remote])
+			{
+				released = true;
+				remote_is_allowed[portal->config.remote] = false;
+			}
+
+		spinlock_unlock(&allow_lock);
+	}
+
+	return (0);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_awrite()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_awrite(struct mportal * portal, const void * buffer, size_t size)
+{
+	ssize_t ret;                    /* Return value.               */
+	size_t n;                       /* Size of current data piece. */
+	size_t sended;                  /* Amount of data sended.      */
+	size_t remainder;               /* Remainder of total data.    */
+	size_t times;                   /* Number of pieces.           */
+	struct mportal_message message; /* Message buffer.             */
+
+	/* Waits allows. */
+	if ((ret = do_kportal_wait_allow(portal)) < 0)
+		return (ret);
+
+	/* Sends header. */
+	message.header   = true;
+	message.eof      = false;
+	message._.config = portal->config;
+
+again:
+	spinlock_lock(&write_lock[portal->config.remote]);
+
+		if (resource_is_busy(&write_channels[portal->config.remote]))
+		{
+			spinlock_unlock(&write_lock[portal->config.remote]);
+			goto again;
+		}
+
+		resource_set_busy(&write_channels[portal->config.remote]);
+
+		/* Reads a piece of the message. */
+		if ((ret = kmailbox_write(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+			goto error;
+
+		/* Sends data. */
+		sended    = 0ULL;
+		times     = size / MPORTAL_MESSAGE_DATA_SIZE;
+		remainder = size - (times * MPORTAL_MESSAGE_DATA_SIZE);
+
+		message.header = false;
+		message.eof    = false;
+
+		for (size_t t = 0; t < times + (remainder != 0); ++t)
+		{
+			n = (t != times) ? MPORTAL_MESSAGE_DATA_SIZE : remainder;
+
+			kmemcpy(message._.data, buffer, n);
+
+			sended      += (message.size = n);
+			message.eof  = (sended == size);
+
+			/* Reads a piece of the message. */
+			if ((ret = kmailbox_write(portal->mdata, &message, MPORTAL_MESSAGE_SIZE)) < 0)
+				goto error;
+
+			/* Next pieces. */
+			buffer += n;
+		}
+
+		ret = size;
+
+error:
+		resource_set_notbusy(&write_channels[portal->config.remote]);
+	spinlock_unlock(&write_lock[portal->config.remote]);
+
+	if (ret >= 0)
+		portal->volume += size;
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_kportal_awrite_local()                                                  *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE ssize_t do_kportal_awrite_local(struct mportal * portal, const void * buffer, size_t size)
+{
+	size_t n;                    /* Size of current data piece. */
+	uint64_t t0;                 /* Clock value.                */
+	uint64_t t1;                 /* Clock value.                */
+	size_t remainder;            /* Remainder of total data.    */
+	struct mportal_buffer * buf; /* Auxiliar buffer pointer.    */
+	struct mportal_buffer * aux; /* Auxiliar buffer pointer.    */
+
+	buf       = NULL;
+	remainder = size;
+
+again:
+	spinlock_lock(&local_lock);
+
+		while (remainder)
+		{
+			n = (remainder < MPORTAL_BUFFER_SIZE) ? remainder : MPORTAL_BUFFER_SIZE;
+
+			/* Has any buffer free? */
+			if ((aux = kportal_buffer_alloc(buf, &portal->config)) != NULL)
+				buf = aux;
+			else
+			{
+				spinlock_unlock(&local_lock);
+				goto again;
+			}
+
+			kclock(&t0);
+				kmemcpy(buf->data, buffer, n);
+			kclock(&t1);
+			portal->latency += (t1 - t0);
+
+			remainder -= n;
+			buffer    += n;
+			buf->size += n;
+		}
+
+	spinlock_unlock(&local_lock);
+
+	portal->volume += size;
+
+	return (size);
+}
+
+/*----------------------------------------------------------------------------*
+ * kportal_awrite()                                                           *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The kportal_awrite() asynchronously write @p size bytes
+ * of data pointed to by @p buffer to the output portal @p portalid.
+ */
+PUBLIC ssize_t kportal_awrite(int portalid, const void * buffer, size_t size)
+{
+	ssize_t ret;      /* Return value. */
+	uint64_t latency; /* Latency.      */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
+	/* Invalid size. */
+	if (size == 0 || size > KPORTAL_MAX_SIZE)
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_writable(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		resource_set_busy(&mportals[portalid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	/* Is local communication? */
+	if (node_is_local(mportals[portalid].config.remote))
+		ret = do_kportal_awrite_local(&mportals[portalid], buffer, size);
+	else
+	{
+		ret = do_kportal_awrite(&mportals[portalid], buffer, size);
+
+		if (ret >= 0)
+		{
+			kmailbox_ioctl(mportals[portalid].mdata, MAILBOX_IOCTL_GET_LATENCY, &latency);
+			mportals[portalid].latency += latency;
+		}
+	}
+
+	spinlock_lock(&global_lock);
+		resource_set_notbusy(&mportals[portalid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_wait()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_wait() waits for asyncrhonous operations in
+ * the input/output portal @p portalid to complete.
+ */
+PUBLIC int kportal_wait(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_read()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_read() synchronously read @p size bytes of
+ * data pointed to by @p buffer from the input portal @p portalid.
+ */
+PUBLIC ssize_t kportal_read(int portalid, void * buffer, size_t size)
+{
+	return (kportal_aread(portalid, buffer, size));
+}
+
+/*============================================================================*
+ * kportal_write()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_write() synchronously write @p size bytes of
+ * data pointed to by @p buffer to the output portal @p portalid.
+ */
+PUBLIC ssize_t kportal_write(int portalid, const void * buffer, size_t size)
+{
+	return (kportal_awrite(portalid, buffer, size));
+}
+
+/*============================================================================*
+ * kportal_ioctl()                                                            *
+ *============================================================================*/
+
+/**
+ * @details The kportal_ioctl() reads the measurement parameter associated
+ * with the request id @p request of the portal @p portalid.
+ */
+PUBLIC int kportal_ioctl(int portalid, unsigned request, ...)
+{
+	int ret;      /* Return value.  */
+	va_list args; /* Argument list. */
+
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&mportals[portalid].resource))
+			goto error;
+
+		ret = 0;
+
+		va_start(args, request);
+
+		/* Parse request. */
+		switch (request)
+		{
+			/* Get the amount of data transferred so far. */
+			case KPORTAL_IOCTL_GET_VOLUME:
+			{
+				size_t *volume;
+				volume = va_arg(args, size_t *);
+				*volume = mportals[portalid].volume;
+			} break;
+
+			/* Get the cumulative transfer latency. */
+			case KPORTAL_IOCTL_GET_LATENCY:
+			{
+				uint64_t *latency;
+				latency = va_arg(args, uint64_t *);
+				*latency = mportals[portalid].latency;
+			} break;
+
+			/* Operation not supported. */
+			default:
+				ret = (-ENOTSUP);
+				break;
+		}
+
+		va_end(args);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+
+/*============================================================================*
+ * kportal_write()                                                            *
+ *============================================================================*/
+
+/**
+ * @details Write details.
+ */
+PUBLIC int kportal_get_port(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&mportals[portalid].resource))
+			goto error;
+
+		ret = mportals[portalid].config.local_port;
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kportal_init()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_init() Initializes underlying mailboxes.
+ */
+PUBLIC void kportal_init(void)
+{
+	unsigned local = knode_get_num();
+
+	kprintf("[user][portal] Initializes portal module (mailbox implementation)");
+
+	/* Create input mailbox. */
+	KASSERT(
+		(mallow_in = kcall2(
+			NR_mailbox_create,
+			(word_t) local,
+			(word_t) (MAILBOX_PORT_NR - 2)
+		)) >= 0
+	);
+
+	/* Opens output mailboxes. */
+	for (unsigned i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
+	{
+		if (i == local)
+			continue;
+
+		KASSERT(
+			(mallow_outs[i] = kcall2(
+				NR_mailbox_open,
+				(word_t) i,
+				(word_t) (MAILBOX_PORT_NR - 2)
+			)) >= 0
+		);
+
+		KASSERT(
+			(mdata_ins[i] = kcall2(
+				NR_mailbox_create,
+				(word_t) local,
+				(word_t) (MAILBOX_PORT_NR - 3 - i)
+			)) >= 0
+		);
+
+		KASSERT(
+			(mdata_outs[i] = kcall2(
+				NR_mailbox_open,
+				(word_t) i,
+				(word_t) (MAILBOX_PORT_NR - 3 - local)
+			)) >= 0
+		);
+
+		/* Set channel busy. */
+		resource_set_used(&read_channels[i]);
+	}
+
+	kportal_is_initialized = true;
+}
+
+#else
+extern int make_iso_compilers_happy;
+#endif /* __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/libnanvix/ikc/msync.c
+++ b/src/libnanvix/ikc/msync.c
@@ -1,0 +1,679 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define __NEED_RESOURCE
+
+#include <nanvix/kernel/kernel.h>
+
+#if __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX
+
+#include <nanvix/sys/noc.h>
+#include <nanvix/sys/mailbox.h>
+#include <posix/errno.h>
+
+/**
+ * @brief Indicates if ksync_init is called.
+ */
+PRIVATE bool ksync_is_initialized = false;
+
+/**
+ * @name Protections.
+ */
+/**@{*/
+PRIVATE spinlock_t global_lock = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t wait_lock   = SPINLOCK_UNLOCKED;
+PRIVATE spinlock_t signal_lock = SPINLOCK_UNLOCKED;
+/**@}*/
+
+/**
+ * @name Mailbox channels.
+ */
+/**@{*/
+PRIVATE int inbox = -1;
+PRIVATE int outboxes[PROCESSOR_NOC_NODES_NUM] = {
+	[0 ... (PROCESSOR_NOC_NODES_NUM - 1)] = -1,
+};
+/**@}*/
+
+/*============================================================================*
+ * Sync hash                                                                  *
+ *============================================================================*/
+
+/**
+ * @name Hash macros.
+ */
+/**@{*/
+#define MSYNC_HASH_SIZE (sizeof(struct msync_hash))
+#define MSYNC_HASH_NULL ((struct msync_hash){-1, 0, -1, 0, 0, 0})
+/**@}*/
+
+/**
+ * @brief Hash structure.
+ */
+struct msync_hash
+{
+	uint64_t source    :  5; /**< Source nodenum.   */
+	uint64_t type      :  1; /**< Type of the sync. */
+	uint64_t master    :  5; /**< Master nodenum.   */
+	uint64_t nodeslist : 20; /**< Nodes list.       */
+	uint64_t barrier   : 20; /**< Barrier variable. */
+	uint64_t unused    : 13; /**< Unused.           */
+};
+
+/*============================================================================*
+ * Sync Structures.                                                           *
+ *============================================================================*/
+
+/**
+ * @brief Table of active synchronization points.
+ */
+PRIVATE struct msync
+{
+	/*
+	 * XXX: Don't Touch! This Must Come First!
+	 */
+	struct resource resource; /**< Generic resource information. */
+	int refcount;             /**< Counter of references.        */
+	int nbarriers;            /**< Counter of barriers.          */
+	struct msync_hash hash;   /**< Sync hash.                    */
+} ALIGN(sizeof(dword_t)) msyncs[(SYNC_CREATE_MAX + SYNC_OPEN_MAX)] = {
+	[0 ... (SYNC_CREATE_MAX + SYNC_OPEN_MAX - 1)] = {
+		.resource  = RESOURCE_INITIALIZER,
+		.refcount  = 0,
+		.nbarriers = 0,
+		.hash      = MSYNC_HASH_NULL,
+	},
+};
+
+/**
+ * @brief Resource pool.
+ */
+PRIVATE const struct resource_pool msyncpool = {
+	msyncs, (SYNC_CREATE_MAX + SYNC_OPEN_MAX), sizeof(struct msync)
+};
+
+/*============================================================================*
+ * ksync_build_nodeslist()                                                    *
+ *============================================================================*/
+
+PRIVATE int ksync_build_nodeslist(const int * nodes, int nnodes)
+{
+	int nodeslist = 0; /* Bit-stream of nodes. */
+
+	for (int j = 0; j < nnodes; j++)
+		nodeslist |= (1ULL << nodes[j]);
+
+	return (nodeslist);
+}
+
+/*============================================================================*
+ * ksync_search()                                                             *
+ *============================================================================*/
+
+PRIVATE int ksync_search(struct msync_hash * hash, int input)
+{
+	for (unsigned i = 0; i < (SYNC_CREATE_MAX + SYNC_OPEN_MAX); ++i)
+	{
+		if (!resource_is_used(&msyncs[i].resource))
+			continue;
+
+		if (input)
+		{
+			if (!resource_is_readable(&msyncs[i].resource))
+				continue;
+		}
+
+		/* Output. */
+		else if (!resource_is_writable(&msyncs[i].resource))
+			continue;
+
+		if (msyncs[i].hash.type != hash->type)
+			continue;
+
+		if (msyncs[i].hash.master != hash->master)
+			continue;
+
+		if (msyncs[i].hash.nodeslist != hash->nodeslist)
+			continue;
+
+		return (i);
+	}
+
+	return (-EINVAL);
+}
+
+/*============================================================================*
+ * ksync_nodelist_is_valid()                                                  *
+ *============================================================================*/
+
+/**
+ * @brief Node list validation.
+ *
+ * @param local  Logic ID of local node.
+ * @param nodes  IDs of target NoC nodes.
+ * @param nnodes Number of target NoC nodes.
+ *
+ * @return Non zero if node list is valid and zero otherwise.
+ */
+PRIVATE int ksync_nodelist_is_valid(const int * nodes, int nnodes, int is_the_one)
+{
+	int local;       /* Local node.          */
+	uint64_t checks; /* Bit-stream of nodes. */
+
+	checks = 0ULL;
+	local  = knode_get_num();
+
+	/* Is the local the one? */
+	if (is_the_one && (nodes[0] != local))
+		return (0);
+
+	/* Isn't the local the one? */
+	if (!is_the_one && (nodes[0] == local))
+		return (0);
+
+	/* Build nodelist. */
+	for (int i = 0; i < nnodes; ++i)
+	{
+		/* Invalid node. */
+		if (!WITHIN(nodes[i], 0, PROCESSOR_NOC_NODES_NUM))
+			return (0);
+
+		/* Does a node appear twice? */
+		if (checks & (1ULL << nodes[i]))
+			return (0);
+
+		checks |= (1ULL << nodes[i]);
+	}
+
+	/* Is the local node founded? */
+	return (checks & (1ULL << local));
+}
+
+/*============================================================================*
+ * ksync_create()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The ksync_create() function creates an input sync
+ * and attaches it to the list NoC node @p nodes.
+ */
+PRIVATE int do_ksync_alloc(const int * nodes, int nnodes, int type, int input)
+{
+	int syncid;             /* Synchronization point.            */
+	int is_the_one;         /* Indicates rule of the local node. */
+	struct msync_hash hash; /* Sync hash.                        */
+
+	KASSERT(ksync_is_initialized);
+
+	/* Invalid nodes list. */
+	if (nodes == NULL)
+		return (-EINVAL);
+
+	/* Invalid number of nodes. */
+	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
+		return(-EINVAL);
+
+	/* Invalid sync type. */
+	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
+		return (-EINVAL);
+
+	is_the_one = input ? (type == SYNC_ALL_TO_ONE) : (type == SYNC_ONE_TO_ALL);
+
+	/* Invalid nodes list. */
+	if (!ksync_nodelist_is_valid(nodes, nnodes, is_the_one))
+		return (-EINVAL);
+
+	hash.source    = knode_get_num();
+	hash.type      = type;
+	hash.master    = nodes[0];
+	hash.nodeslist = ksync_build_nodeslist(nodes, nnodes);
+
+	if (input)
+		hash.barrier = 0;
+	else
+	{
+		/* Who should it sent to? */
+		hash.barrier = (type == SYNC_ONE_TO_ALL)   ?
+			(hash.nodeslist & ~(1 << hash.master)) : /**< Master notifies All. */
+			(hash.nodeslist & (1 << hash.master));   /**< All notify Master.   */
+	}
+
+	spinlock_lock(&global_lock);
+
+		/* Previous alloc. */
+		if ((syncid = ksync_search(&hash, input)) >= 0)
+			msyncs[syncid].refcount++;
+
+		/* First alloc. */
+		else
+		{
+			/* Allocate a msync point. */
+			if ((syncid = resource_alloc(&msyncpool)) >= 0)
+			{
+				msyncs[syncid].refcount  = 1;
+				msyncs[syncid].nbarriers = 0;
+				msyncs[syncid].hash      = hash;
+				if (input)
+					resource_set_rdonly(&msyncs[syncid].resource);
+				else
+					resource_set_wronly(&msyncs[syncid].resource);
+			}
+		}
+
+	spinlock_unlock(&global_lock);
+
+	return (syncid);
+}
+/*============================================================================*
+ * ksync_create()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The ksync_create() function creates an input sync
+ * and attaches it to the list NoC node @p nodes.
+ */
+PUBLIC int ksync_create(const int * nodes, int nnodes, int type)
+{
+	return (do_ksync_alloc(nodes, nnodes, type, true));
+}
+
+/*============================================================================*
+ * ksync_open()                                                               *
+ *============================================================================*/
+
+/**
+ * @details The ksync_open() function opens an output sync to the
+ * NoC node list @p nodes.
+ */
+PUBLIC int ksync_open(const int * nodes, int nnodes, int type)
+{
+	return (do_ksync_alloc(nodes, nnodes, type, false));
+}
+
+/*============================================================================*
+ * do_ksync_release()                                                         *
+ *============================================================================*/
+
+/**
+ * @details The do_ksync_release() function release @p syncid.
+ */
+PRIVATE int do_ksync_release(int syncid, int input)
+{
+	int ret; /* Return value. */
+
+	/* Invalid syncid. */
+	if (!WITHIN(syncid, 0, SYNC_CREATE_MAX + SYNC_OPEN_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		if (!resource_is_used(&msyncs[syncid].resource))
+			goto error;
+
+		if (input)
+		{
+			if (!resource_is_readable(&msyncs[syncid].resource))
+				goto error;
+		}
+
+		/* Output. */
+		else if (!resource_is_writable(&msyncs[syncid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		if (resource_is_busy(&msyncs[syncid].resource))
+			goto error;
+
+		/* Decrement references. */
+		msyncs[syncid].refcount--;
+
+		if (!msyncs[syncid].refcount)
+		{
+			resource_free(&msyncpool, syncid);
+			msyncs[syncid].hash = MSYNC_HASH_NULL;
+		}
+
+		ret = (0);
+
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * ksync_unlink()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The ksync_unlink() function removes and releases the underlying
+ * resources associated to the input sync @p syncid.
+ */
+PUBLIC int ksync_unlink(int syncid)
+{
+	return (do_ksync_release(syncid, true));
+}
+
+/*============================================================================*
+ * ksync_wait()                                                               *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * ksync_close()                                                              *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The ksync_close() function closes and releases the
+ * underlying resources associated to the output sync @p syncid.
+ */
+PUBLIC int ksync_close(int syncid)
+{
+	return (do_ksync_release(syncid, false));
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_ignore_signal()                                                      *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE void ksync_ignore_signal(char * message, struct msync_hash * hash)
+{
+	int source    = hash->source;
+	int type      = hash->type;
+	int master    = hash->master;
+	int nodeslist = hash->nodeslist;
+
+	kprintf("[sync] %s (source:%d, type:%d, master:%d, nodeslist:%d)",
+		message,
+		source,
+		type,
+		master,
+		nodeslist
+	);
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_barrier_is_complete()                                                *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int ksync_barrier_is_complete(struct msync * rx)
+{
+	int received; /* Received signals. */
+	int expected; /* Expected signals. */
+
+	received = rx->hash.barrier;
+
+	/* Does master notifies it? */
+	if (rx->hash.type == SYNC_ONE_TO_ALL)
+		expected = (rx->hash.nodeslist & (1 << rx->hash.master));
+
+	/* Does slaves notifies it? */
+	else
+		expected = (rx->hash.nodeslist & ~(1 << rx->hash.master));
+
+	return (received == expected);
+}
+
+/*----------------------------------------------------------------------------*
+ * do_ksync_wait()                                                            *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int do_ksync_wait(struct msync * sync)
+{
+	int syncid;             /* Synchronization point. */
+	struct msync_hash hash; /* Hash buffer.           */
+
+	spinlock_lock(&global_lock);
+		/* Complete a synchronization. */
+		if (sync->nbarriers)
+		{
+			sync->nbarriers--;
+			spinlock_unlock(&global_lock);
+
+			/* Success. */
+			return (0);
+		}
+	spinlock_unlock(&global_lock);
+
+	spinlock_lock(&wait_lock);
+
+		spinlock_lock(&global_lock);
+			/* Did the last message release me? */
+			if (sync->nbarriers)
+				goto release;
+		spinlock_unlock(&global_lock);
+
+		if (kmailbox_read(inbox, &hash, MSYNC_HASH_SIZE) != MSYNC_HASH_SIZE)
+		{
+			spinlock_unlock(&wait_lock);
+			return (-EAGAIN);
+		}
+
+		spinlock_lock(&global_lock);
+
+			if ((syncid = ksync_search(&hash, true)) < 0)
+			{
+				ksync_ignore_signal("Drop signal", &hash);
+				goto release;
+			}
+
+			if (msyncs[syncid].hash.barrier & (1 << hash.source))
+			{
+				ksync_ignore_signal("Double signal", &hash);
+				goto release;
+			}
+
+			msyncs[syncid].hash.barrier |= (1 << hash.source);
+
+			if (ksync_barrier_is_complete(&msyncs[syncid]))
+			{
+				msyncs[syncid].hash.barrier = 0;
+				msyncs[syncid].nbarriers++;
+			}
+
+release:
+		spinlock_unlock(&global_lock);
+	spinlock_unlock(&wait_lock);
+
+	/* Do again. */
+	return (1);
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_wait()                                                               *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The ksync_wait() waits incomming signal on a input sync @p syncid.
+ */
+PUBLIC int ksync_wait(int syncid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid syncid. */
+	if (!WITHIN(syncid, 0, SYNC_CREATE_MAX + SYNC_OPEN_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&msyncs[syncid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_readable(&msyncs[syncid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&msyncs[syncid].resource))
+			goto error;
+
+		resource_set_busy(&msyncs[syncid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	while ((ret = do_ksync_wait(&msyncs[syncid])) > 0);
+
+	spinlock_lock(&global_lock);
+		resource_set_notbusy(&msyncs[syncid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * ksync_signal()                                                             *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * do_ksync_signal()                                                          *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE int do_ksync_signal(int syncid)
+{
+	int ret; /* Return value. */
+
+	ret = (-EINVAL);
+
+	spinlock_lock(&signal_lock);
+
+		/* Sends a signal to each target node. */
+		for (unsigned target = 0; target < PROCESSOR_NOC_NODES_NUM; ++target)
+		{
+			/* Is the target valid? */
+			if (msyncs[syncid].hash.barrier & (1 << target))
+			{
+				ret = kmailbox_write(
+					outboxes[target],
+					&msyncs[syncid].hash,
+					MSYNC_HASH_SIZE
+				);
+
+				/* Error occurred? */
+				if (ret != MSYNC_HASH_SIZE)
+					break;
+			}
+		}
+
+	spinlock_unlock(&signal_lock);
+
+	return (ret);
+}
+
+/*----------------------------------------------------------------------------*
+ * ksync_signal()                                                             *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @details The ksync_signal() emmit a signal from a output sync @p syncid.
+ */
+PUBLIC int ksync_signal(int syncid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid syncid. */
+	if (!WITHIN(syncid, 0, SYNC_CREATE_MAX + SYNC_OPEN_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&global_lock);
+
+		ret = (-EBADF);
+
+		/* Bad sync. */
+		if (!resource_is_used(&msyncs[syncid].resource))
+			goto error;
+
+		/* Bad sync. */
+		if (!resource_is_writable(&msyncs[syncid].resource))
+			goto error;
+
+		ret = (-EBUSY);
+
+		/* Busy sync. */
+		if (resource_is_busy(&msyncs[syncid].resource))
+			goto error;
+
+		resource_set_busy(&msyncs[syncid].resource);
+
+	spinlock_unlock(&global_lock);
+
+	ret = do_ksync_signal(syncid);
+
+	spinlock_lock(&global_lock);
+		resource_set_notbusy(&msyncs[syncid].resource);
+error:
+	spinlock_unlock(&global_lock);
+
+	return (ret < 0) ? (ret) : (0);
+}
+
+/*============================================================================*
+ * ksync_init()                                                               *
+ *============================================================================*/
+
+/**
+ * @details The ksync_init() Initializes underlying mailboxes.
+ */
+PUBLIC void ksync_init(void)
+{
+	int local; /* Local nodenum. */
+
+	kprintf("[user][sync] Initializes sync module (mailbox implementation)");
+
+	local = knode_get_num();
+
+	/* Create input mailbox. */
+	KASSERT(
+		(inbox = kcall2(
+			NR_mailbox_create,
+			(word_t) local,
+			(word_t) (MAILBOX_PORT_NR - 1)
+		)) >= 0
+	);
+
+	/* Opens output mailboxes. */
+	for (unsigned i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
+	{
+		KASSERT(
+			(outboxes[i] = kcall2(
+				NR_mailbox_open,
+				(word_t) i,
+				(word_t) (MAILBOX_PORT_NR - 1)
+			)) >= 0
+		);
+	}
+
+	ksync_is_initialized = true;
+}
+
+#else
+extern int make_iso_compilers_happy;
+#endif /* __TARGET_HAS_MAILBOX && __NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/libnanvix/ikc/noc.c
+++ b/src/libnanvix/ikc/noc.c
@@ -60,3 +60,29 @@ int kcluster_get_num(void)
 
 	return (ret);
 }
+
+/*============================================================================*
+ * kcomm_get_port()                                                           *
+ *============================================================================*/
+
+/*
+ * @see kernel_comm_get_num()
+ */
+int kcomm_get_port(int id, int type)
+{
+	int ret;
+
+	if (id < 0)
+		return (-EINVAL);
+
+	if ((type != COMM_TYPE_MAILBOX) && (type != COMM_TYPE_PORTAL))
+		return (-EINVAL);
+
+	ret = kcall2(
+		NR_comm_get_port,
+		(word_t) id,
+		(word_t) type
+	);
+
+	return (ret);
+}

--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -24,7 +24,7 @@
 
 #include <nanvix/kernel/kernel.h>
 
-#if __TARGET_HAS_PORTAL
+#if __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX
 
 #include <nanvix/sys/noc.h>
 #include <posix/errno.h>
@@ -181,9 +181,9 @@ int kportal_close(int portalid)
  * @details The kportal_aread() asynchronously read @p size bytes of
  * data pointed to by @p buffer from the input portal @p portalid.
  */
-int kportal_aread(int portalid, void * buffer, size_t size)
+ssize_t kportal_aread(int portalid, void * buffer, size_t size)
 {
-	int ret;
+	ssize_t ret;
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -213,9 +213,9 @@ int kportal_aread(int portalid, void * buffer, size_t size)
  * @details The kportal_awrite() asynchronously write @p size bytes
  * of data pointed to by @p buffer to the output portal @p portalid.
  */
-int kportal_awrite(int portalid, const void * buffer, size_t size)
+ssize_t kportal_awrite(int portalid, const void * buffer, size_t size)
 {
-	int ret;
+	ssize_t ret;
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -401,6 +401,18 @@ int kportal_ioctl(int portalid, unsigned request, ...)
 	return (ret);
 }
 
+/*============================================================================*
+ * kportal_init()                                                             *
+ *============================================================================*/
+
+/**
+ * @details The kportal_init() Initializes portal system.
+ */
+PUBLIC void kportal_init(void)
+{
+	kprintf("[user][portal] Initializes portal module");
+}
+
 #else
 extern int make_iso_compilers_happy;
-#endif /* __TARGET_HAS_PORTAL */
+#endif /* __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -190,7 +190,7 @@ int kportal_aread(int portalid, void * buffer, size_t size)
 		return (-EINVAL);
 
 	/* Invalid size. */
-	if (size == 0 || size > HAL_PORTAL_MAX_SIZE)
+	if (size == 0 || size > KPORTAL_MESSAGE_DATA_SIZE)
 		return (-EINVAL);
 
 	do
@@ -222,7 +222,7 @@ int kportal_awrite(int portalid, const void * buffer, size_t size)
 		return (-EINVAL);
 
 	/* Invalid size. */
-	if (size == 0 || size > HAL_PORTAL_MAX_SIZE)
+	if (size == 0 || size > KPORTAL_MESSAGE_DATA_SIZE)
 		return (-EINVAL);
 
 	do
@@ -267,10 +267,10 @@ int kportal_wait(int portalid)
  */
 ssize_t kportal_write(int portalid, const void * buffer, size_t size)
 {
-	ssize_t ret;       /* Return value.               */
-	ssize_t n;         /* Size of current data piece. */
-	ssize_t remainder; /* Remainder of total data.    */
-	size_t times;      /* Number of pieces.           */
+	ssize_t ret;      /* Return value.               */
+	size_t n;         /* Size of current data piece. */
+	size_t remainder; /* Remainder of total data.    */
+	size_t times;     /* Number of pieces.           */
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -280,12 +280,12 @@ ssize_t kportal_write(int portalid, const void * buffer, size_t size)
 	if (size == 0 || size > KPORTAL_MAX_SIZE)
 		return (-EINVAL);
 
-	times     = size / HAL_PORTAL_MAX_SIZE;
-	remainder = size - (times * HAL_PORTAL_MAX_SIZE);
+	times     = size / KPORTAL_MESSAGE_DATA_SIZE;
+	remainder = size - (times * KPORTAL_MESSAGE_DATA_SIZE);
 
 	for (size_t t = 0; t < times + (remainder != 0); ++t)
 	{
-		n = (t != times) ? HAL_PORTAL_MAX_SIZE : remainder;
+		n = (t != times) ? KPORTAL_MESSAGE_DATA_SIZE : remainder;
 
 		/* Sends a piece of the message. */
 		if ((ret = kportal_awrite(portalid, buffer, n)) < 0)
@@ -312,12 +312,12 @@ ssize_t kportal_write(int portalid, const void * buffer, size_t size)
  */
 ssize_t kportal_read(int portalid, void * buffer, size_t size)
 {
-	ssize_t ret;       /* Return value.               */
-	ssize_t n;         /* Size of current data piece. */
-	ssize_t remainder; /* Remainder of total data.    */
-	size_t times;      /* Number of pieces.           */
-	int remote;
-	int port;
+	ssize_t ret;      /* Return value.               */
+	size_t n;         /* Size of current data piece. */
+	size_t remainder; /* Remainder of total data.    */
+	size_t times;     /* Number of pieces.           */
+	int remote;       /* Number of target remote.    */
+	int port;         /* Number of target port.      */
 
 	/* Invalid buffer. */
 	if (buffer == NULL)
@@ -327,8 +327,8 @@ ssize_t kportal_read(int portalid, void * buffer, size_t size)
 	if (size == 0 || size > KPORTAL_MAX_SIZE)
 		return (-EINVAL);
 
-	times     = size / HAL_PORTAL_MAX_SIZE;
-	remainder = size - (times * HAL_PORTAL_MAX_SIZE);
+	times     = size / KPORTAL_MESSAGE_DATA_SIZE;
+	remainder = size - (times * KPORTAL_MESSAGE_DATA_SIZE);
 	ret       = (-EINVAL);
 	spinlock_lock(&kportal_lock);
 		remote = kportal_allows[portalid].remote;
@@ -337,7 +337,7 @@ ssize_t kportal_read(int portalid, void * buffer, size_t size)
 
 	for (size_t t = 0; t < times + (remainder != 0); ++t)
 	{
-		n = (t != times) ? HAL_PORTAL_MAX_SIZE : remainder;
+		n = (t != times) ? KPORTAL_MESSAGE_DATA_SIZE : remainder;
 
 		/* Repeat while reading valid messages for another ports. */
 		do

--- a/src/libnanvix/ikc/stdsync.c
+++ b/src/libnanvix/ikc/stdsync.c
@@ -181,7 +181,6 @@ int __stdsync_cleanup(void)
 int stdsync_fence(void)
 {
 	int tid;
-	int ret;
 
 	if ((tid = kthread_self()) > THREAD_MAX)
 		return (-1);
@@ -190,8 +189,8 @@ int stdsync_fence(void)
 	/* Master cluster */
 	if (cluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
 	{
-		ret = ksync_wait(__stdbarrier[tid][0]);
-		ret = ksync_signal(__stdbarrier[tid][1]);
+		KASSERT(ksync_wait(__stdbarrier[tid][0]) == 0);
+		KASSERT(ksync_signal(__stdbarrier[tid][1]) == 0);
 	}
 
 	/* Slave cluster. */
@@ -202,11 +201,11 @@ int stdsync_fence(void)
 			delay(CLUSTER_FREQ);
 		#endif
 
-		ret = ksync_signal(__stdbarrier[tid][0]);
-		ret = ksync_wait(__stdbarrier[tid][1]);
+		KASSERT(ksync_signal(__stdbarrier[tid][0]) == 0);
+		KASSERT(ksync_wait(__stdbarrier[tid][1]) == 0);
 	}
 
-	return (ret);
+	return (0);
 }
 
 /**

--- a/src/libnanvix/ikc/stdsync.c
+++ b/src/libnanvix/ikc/stdsync.c
@@ -29,12 +29,13 @@
 #include <nanvix/sys/perf.h>
 #include <nanvix/sys/thread.h>
 #include <nanvix/runtime/stdikc.h>
+#include <nanvix/runtime/barrier.h>
 
 /**
  * @brief Kernel standard sync.
  */
-static int __stdbarrier[THREAD_MAX + 1][2] = {
-	[0 ... (THREAD_MAX)] = { -1, -1 },
+static barrier_t __stdbarrier[THREAD_MAX + 1] = {
+	[0 ... (THREAD_MAX)] = BARRIER_NULL,
 };
 
 #ifndef __unix64__
@@ -102,48 +103,17 @@ static void build_node_list(int *nodes, int nioclusters, int ncclusters)
 int __stdsync_setup(void)
 {
 	int tid;
-	int ret;
 	int nodes[PROCESSOR_CLUSTERS_NUM];
 
-	tid = kthread_self();
+	if ((tid = kthread_self()) > THREAD_MAX)
+		return (-1);
 
 	build_node_list(nodes, PROCESSOR_IOCLUSTERS_NUM, PROCESSOR_CCLUSTERS_NUM);
 
-	/* Master cluster */
-	if (kcluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
-	{
-		ret = __stdbarrier[tid][0] = ksync_create(
-			nodes, PROCESSOR_CLUSTERS_NUM, SYNC_ALL_TO_ONE
-		);
-		if (ret >= 0)
-		{
-			ret = __stdbarrier[tid][1] = ksync_open(
-				nodes, PROCESSOR_CLUSTERS_NUM, SYNC_ONE_TO_ALL
-			);
-
-			if (ret < 0)
-				ksync_unlink(__stdbarrier[tid][0]);
-		}
-	}
-
-	else
-	{
-		ret = __stdbarrier[tid][0] = ksync_open(
-			nodes, PROCESSOR_CLUSTERS_NUM, SYNC_ALL_TO_ONE
-		);
-		if (ret >= 0)
-		{
-			ret = __stdbarrier[tid][1] = ksync_create(
-				nodes, PROCESSOR_CLUSTERS_NUM, SYNC_ONE_TO_ALL
-			);
-
-			if (ret < 0)
-				ksync_close(__stdbarrier[tid][0]);
-		}
-	}
+	__stdbarrier[tid] = barrier_create(nodes, PROCESSOR_CLUSTERS_NUM);
 
 	/* Slave cluster. */
-	return ((ret < 0) ? -1 : -0);
+	return (0);
 }
 
 /**
@@ -158,18 +128,7 @@ int __stdsync_cleanup(void)
 	if ((tid = kthread_self()) > THREAD_MAX)
 		return (-1);
 
-	/* Master cluster */
-	if (kcluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
-	{
-		ret = ksync_unlink(__stdbarrier[tid][0]);
-		ret = ksync_close(__stdbarrier[tid][1]);
-	}
-
-	else
-	{
-		ret = ksync_close(__stdbarrier[tid][0]);
-		ret = ksync_unlink(__stdbarrier[tid][1]);
-	}
+	ret = barrier_destroy(__stdbarrier[tid]);
 
 	return (ret);
 }
@@ -181,44 +140,14 @@ int __stdsync_cleanup(void)
 int stdsync_fence(void)
 {
 	int tid;
+	int ret;
 
 	if ((tid = kthread_self()) > THREAD_MAX)
 		return (-1);
 
+	ret = barrier_wait(__stdbarrier[tid]);
 
-	/* Master cluster */
-	if (kcluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
-	{
-		KASSERT(ksync_wait(__stdbarrier[tid][0]) == 0);
-		KASSERT(ksync_signal(__stdbarrier[tid][1]) == 0);
-	}
-
-	/* Slave cluster. */
-	else
-	{
-		/* Waits one second. */
-		#ifndef __unix64__
-			delay(CLUSTER_FREQ);
-		#endif
-
-		KASSERT(ksync_signal(__stdbarrier[tid][0]) == 0);
-		KASSERT(ksync_wait(__stdbarrier[tid][1]) == 0);
-	}
-
-	return (0);
-}
-
-/**
- * @todo TODO: provide a detailed description for this function.
- */
-int stdsync_get(void)
-{
-	int tid;
-
-	if ((tid = kthread_self()) > THREAD_MAX)
-		return (-1);
-
-	return (__stdbarrier[tid][0]);
+	return (ret);
 }
 
 #else

--- a/src/libnanvix/ikc/stdsync.c
+++ b/src/libnanvix/ikc/stdsync.c
@@ -110,7 +110,7 @@ int __stdsync_setup(void)
 	build_node_list(nodes, PROCESSOR_IOCLUSTERS_NUM, PROCESSOR_CCLUSTERS_NUM);
 
 	/* Master cluster */
-	if (cluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
+	if (kcluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
 	{
 		ret = __stdbarrier[tid][0] = ksync_create(
 			nodes, PROCESSOR_CLUSTERS_NUM, SYNC_ALL_TO_ONE
@@ -159,7 +159,7 @@ int __stdsync_cleanup(void)
 		return (-1);
 
 	/* Master cluster */
-	if (cluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
+	if (kcluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
 	{
 		ret = ksync_unlink(__stdbarrier[tid][0]);
 		ret = ksync_close(__stdbarrier[tid][1]);
@@ -187,7 +187,7 @@ int stdsync_fence(void)
 
 
 	/* Master cluster */
-	if (cluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
+	if (kcluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
 	{
 		KASSERT(ksync_wait(__stdbarrier[tid][0]) == 0);
 		KASSERT(ksync_signal(__stdbarrier[tid][1]) == 0);

--- a/src/libnanvix/ikc/sync.c
+++ b/src/libnanvix/ikc/sync.c
@@ -179,6 +179,37 @@ int ksync_unlink(int syncid)
 }
 
 /*============================================================================*
+ * ksync_ioctl()                                                              *
+ *============================================================================*/
+
+/**
+ * @details The ksync_ioctl() reads the measurement parameter associated
+ * with the request id @p request of the sync @p syncid.
+ */
+int ksync_ioctl(int syncid, unsigned request, ...)
+{
+	int ret;
+	va_list args;
+
+	va_start(args, request);
+
+		dcache_invalidate();
+
+		ret = kcall3(
+			NR_sync_ioctl,
+			(word_t) syncid,
+			(word_t) request,
+			(word_t) &args
+		);
+
+		dcache_invalidate();
+
+	va_end(args);
+
+	return (ret);
+}
+
+/*============================================================================*
  * ksync_init()                                                               *
  *============================================================================*/
 

--- a/src/libnanvix/ikc/sync.c
+++ b/src/libnanvix/ikc/sync.c
@@ -40,7 +40,6 @@
 int ksync_create(const int *nodes, int nnodes, int type)
 {
 	int ret;
-	int nodenum;
 
 	/* Invalid nodes list. */
 	if (nodes == NULL)
@@ -54,15 +53,11 @@ int ksync_create(const int *nodes, int nnodes, int type)
 	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
 		return (-EINVAL);
 
-	/* Gets the local node number. */
-	nodenum = processor_node_get_num();
-
-	ret = kcall4(
+	ret = kcall3(
 		NR_sync_create,
 		(word_t) nodes,
 		(word_t) nnodes,
-		(word_t) type,
-		(word_t) nodenum
+		(word_t) type
 	);
 
 	return (ret);
@@ -79,7 +74,6 @@ int ksync_create(const int *nodes, int nnodes, int type)
 int ksync_open(const int *nodes, int nnodes, int type)
 {
 	int ret;
-	int nodenum;
 
 	/* Invalid list of nodes. */
 	if (nodes == NULL)
@@ -93,15 +87,11 @@ int ksync_open(const int *nodes, int nnodes, int type)
 	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
 		return (-EINVAL);
 
-	/* Gets the local node number. */
-	nodenum = processor_node_get_num();
-
-	ret = kcall4(
+	ret = kcall3(
 		NR_sync_open,
 		(word_t) nodes,
 		(word_t) nnodes,
-		(word_t) type,
-		(word_t) nodenum
+		(word_t) type
 	);
 
 	return (ret);
@@ -137,10 +127,13 @@ int ksync_signal(int syncid)
 {
 	int ret;
 
-	ret = kcall1(
-		NR_sync_signal,
-		(word_t) syncid
-	);
+	do
+	{
+		ret = kcall1(
+			NR_sync_signal,
+			(word_t) syncid
+		);
+	} while (ret == -EAGAIN);
 
 	return (ret);
 }

--- a/src/libnanvix/ikc/sync.c
+++ b/src/libnanvix/ikc/sync.c
@@ -24,7 +24,7 @@
 
 #include <nanvix/kernel/kernel.h>
 
-#if __TARGET_HAS_SYNC
+#if __TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX
 
 #include <nanvix/sys/noc.h>
 #include <posix/errno.h>
@@ -178,6 +178,18 @@ int ksync_unlink(int syncid)
 	return (ret);
 }
 
+/*============================================================================*
+ * ksync_init()                                                               *
+ *============================================================================*/
+
+/**
+ * @details The ksync_init() Initializes sync system.
+ */
+PUBLIC void ksync_init(void)
+{
+	kprintf("[user][sync] Initializes sync module");
+}
+
 #else
 extern int make_iso_compilers_happy;
-#endif /* __TARGET_HAS_MAILBOX */
+#endif /* __TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/test/barrier.c
+++ b/src/test/barrier.c
@@ -1,0 +1,92 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <posix/errno.h>
+#include <nanvix/sys/sync.h>
+#include <nanvix/sys/noc.h>
+
+#if (__TARGET_HAS_SYNC)
+
+/*----------------------------------------------------------------------------*
+ * Nodes                                                                      *
+ *----------------------------------------------------------------------------*/
+
+static int _syncin         = -1;
+static int _syncout        = -1;
+static int _node_is_master = 0;
+
+/**
+ * @brief Barrier setup function.
+ */
+void barrier_nodes_setup(const int * nodes, int nnodes, int is_master)
+{
+	KASSERT((nodes != NULL) && (nnodes > 0));
+
+	_node_is_master = is_master;
+
+	if (_node_is_master)
+	{
+		_syncin  = ksync_create(nodes, nnodes, SYNC_ALL_TO_ONE);
+		_syncout = ksync_open(nodes, nnodes, SYNC_ONE_TO_ALL);
+	}
+	else
+	{
+		_syncout = ksync_open(nodes, nnodes, SYNC_ALL_TO_ONE);
+		_syncin  = ksync_create(nodes, nnodes, SYNC_ONE_TO_ALL);
+	}
+
+	KASSERT((_syncout >= 0) && (_syncin >= 0));
+}
+
+/**
+ * @brief Barrier function.
+ */
+void barrier_nodes(void)
+{
+	if (_node_is_master)
+	{
+		ksync_wait(_syncin);
+		ksync_signal(_syncout);
+	}
+	else
+	{
+		ksync_signal(_syncout);
+		ksync_wait(_syncin);
+	}
+}
+
+/**
+ * @brief Barrier cleanup function.
+ */
+void barrier_nodes_cleanup(void)
+{
+	ksync_unlink(_syncin);
+	ksync_close(_syncout);
+
+	_syncin    = -1;
+	_syncout   = -1;
+	_node_is_master = 0;
+}
+
+#endif /* __TARGET_HAS_SYNC */

--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -33,38 +33,9 @@
 
 #if __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL
 
-/**
- * @brief Test's parameters
- */
-#define NR_NODES       2
-#define NR_NODES_MAX   PROCESSOR_NOC_NODES_NUM
-#define MESSAGE_SIZE   1024
-#define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-#else
-	#define SLAVE_NODENUM  1
-#endif
-
 /*============================================================================*
  * Stress Tests                                                               *
  *============================================================================*/
-
-/**
- * @name Number of setups and communications.
- */
-/**@{*/
-#define NSETUPS 1
-#define NCOMMUNICATIONS 1
-#define TEST_MAILBOX_SIZE KMAILBOX_MESSAGE_SIZE
-#define PORTAL_SIZE 512
-#define MAILBOX_SIZE KMAILBOX_MESSAGE_SIZE
-#ifdef __mppa256__
-	#define TEST_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_NPORTS (THREAD_MAX)
-#endif
-/**@}*/
 
 /*============================================================================*
  * Stress Test: Portal Create Unlink                                          *
@@ -402,8 +373,8 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_NPORTS];
-	int portalids[TEST_NPORTS];
+	int mbxids[TEST_THREAD_NPORTS];
+	int portalids[TEST_THREAD_NPORTS];
 	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
@@ -415,20 +386,20 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
 					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_close(portalids[j]) == 0);
 				test_assert(kmailbox_close(mbxids[j]) == 0);
@@ -439,7 +410,7 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
@@ -447,7 +418,7 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -460,7 +431,7 @@ PRIVATE void test_stress_ikc_multiplexing_broadcast(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_unlink(portalids[j]) == 0);
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
@@ -480,8 +451,8 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_NPORTS];
-	int portalids[TEST_NPORTS];
+	int mbxids[TEST_THREAD_NPORTS];
+	int portalids[TEST_THREAD_NPORTS];
 	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
@@ -493,20 +464,20 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
 					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_close(portalids[j]) == 0);
 				test_assert(kmailbox_close(mbxids[j]) == 0);
@@ -517,7 +488,7 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
@@ -525,7 +496,7 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -538,7 +509,7 @@ PRIVATE void test_stress_ikc_multiplexing_gather(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 			{
 				test_assert(kportal_unlink(portalids[j]) == 0);
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
@@ -558,10 +529,10 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 {
 	int local;
 	int remote;
-	int inboxes[TEST_NPORTS];
-	int outboxes[TEST_NPORTS];
-	int inportals[TEST_NPORTS];
-	int outportals[TEST_NPORTS];
+	int inboxes[TEST_THREAD_NPORTS];
+	int outboxes[TEST_THREAD_NPORTS];
+	int inportals[TEST_THREAD_NPORTS];
+	int outportals[TEST_THREAD_NPORTS];
 	char msg_in[PORTAL_SIZE];
 	char msg_out[PORTAL_SIZE];
 
@@ -572,7 +543,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert((inboxes[j] = kmailbox_create(local, j)) >= 0);
 			test_assert((outboxes[j] = kmailbox_open(remote, j)) >= 0);
@@ -584,7 +555,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kmailbox_read(inboxes[k], msg_in, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -605,7 +576,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(outboxes[k], msg_out, MAILBOX_SIZE) == MAILBOX_SIZE);
 
@@ -623,7 +594,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong(void)
 			}
 		}
 
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert(kportal_close(outportals[j]) == 0);
 			test_assert(kportal_unlink(inportals[j]) == 0);
@@ -644,10 +615,10 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 {
 	int local;
 	int remote;
-	int inboxes[TEST_NPORTS];
-	int outboxes[TEST_NPORTS];
-	int inportals[TEST_NPORTS];
-	int outportals[TEST_NPORTS];
+	int inboxes[TEST_THREAD_NPORTS];
+	int outboxes[TEST_THREAD_NPORTS];
+	int inportals[TEST_THREAD_NPORTS];
+	int outportals[TEST_THREAD_NPORTS];
 	char msg_in[PORTAL_SIZE];
 	char msg_out[PORTAL_SIZE];
 
@@ -658,7 +629,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert((inboxes[j] = kmailbox_create(local, j)) >= 0);
 			test_assert((outboxes[j] = kmailbox_open(remote, j)) >= 0);
@@ -670,7 +641,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kmailbox_read(inboxes[k], msg_in, MAILBOX_SIZE) == MAILBOX_SIZE);
@@ -691,7 +662,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(outboxes[k], msg_out, MAILBOX_SIZE) == MAILBOX_SIZE);
 
@@ -709,7 +680,7 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 			}
 		}
 
-		for (int j = 0; j < TEST_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert(kportal_close(outportals[j]) == 0);
 			test_assert(kportal_unlink(inportals[j]) == 0);
@@ -782,12 +753,6 @@ PRIVATE void fence(struct fence *b)
 		spinlock_unlock(&b->lock);
 	}
 }
-
-#ifdef __mppa256__
-	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_THREAD_NPORTS (THREAD_MAX)
-#endif
 
 /*============================================================================*
  * Stress Test: Portal Thread Multiplexing Broadcast                          *

--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -1548,6 +1548,8 @@ void test_ikc(void)
 		{
 			ikc_tests_stress[i].test_fn();
 
+			barrier_nodes();
+
 			if (local == MASTER_NODENUM)
 				nanvix_puts(ikc_tests_stress[i].name);
 		}

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -1073,12 +1073,17 @@ static void test_fault_mailbox_bad_mbxid(void)
 	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
 	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
 
-	test_assert(kmailbox_close(mbx_out + 1) == -EBADF);
-	test_assert(kmailbox_unlink(mbx_in + 1) == -EBADF);
+	test_assert(kmailbox_read(mbx_out, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
+	test_assert(kmailbox_write(mbx_in, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
+
 	test_assert(kmailbox_read(mbx_in + 1, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
-	test_assert(kmailbox_write(mbx_in + 1, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
-	test_assert(kmailbox_wait(mbx_in + 1) == -EBADF);
-	test_assert(kmailbox_ioctl(mbx_in + 1, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EBADF);
+	test_assert(kmailbox_write(mbx_out + 1, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
+
+	test_assert(kmailbox_wait(mbx_out + 1) == -EBADF);
+	test_assert(kmailbox_ioctl(mbx_out + 1, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EBADF);
+
+	test_assert(kmailbox_unlink(mbx_in + 1) == -EBADF);
+	test_assert(kmailbox_close(mbx_out + 1) == -EBADF);
 
 	test_assert(kmailbox_close(mbx_out) == 0);
 	test_assert(kmailbox_unlink(mbx_in) == 0);

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -51,7 +51,7 @@ static void test_api_mailbox_create_unlink(void)
 }
 
 /*============================================================================*
- * API Test: Open Close                                                    *
+ * API Test: Open Close                                                       *
  *============================================================================*/
 
 /**
@@ -2148,6 +2148,8 @@ void test_mailbox(void)
 		for (unsigned i = 0; mailbox_tests_stress[i].test_fn != NULL; i++)
 		{
 			mailbox_tests_stress[i].test_fn();
+
+			barrier_nodes();
 
 			if (nodenum == MASTER_NODENUM)
 				nanvix_puts(mailbox_tests_stress[i].name);

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -32,18 +32,6 @@
 
 #if __TARGET_HAS_MAILBOX
 
-/**
- * @brief Test's parameters
- */
-#define NR_NODES       2
-#define NR_NODES_MAX   PROCESSOR_NOC_NODES_NUM
-#define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-#else
-	#define SLAVE_NODENUM  1
-#endif
-
 /*============================================================================*
  * API Test: Create Unlink                                                    *
  *============================================================================*/
@@ -1093,15 +1081,6 @@ static void test_fault_mailbox_bad_mbxid(void)
  * Stress Tests                                                               *
  *============================================================================*/
 
-/**
- * @name Number of setups and communications.
- */
-/**@{*/
-#define NSETUPS 1
-#define NCOMMUNICATIONS 1
-#define TEST_MAILBOX_NPORTS TEST_MULTIPLEXATION_MBX_PAIRS
-/**@}*/
-
 /*============================================================================*
  * Stress Test: Mailbox Create Unlink                                         *
  *============================================================================*/
@@ -1307,7 +1286,7 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_MAILBOX_NPORTS];
+	int mbxids[TEST_MULTIPLEXATION_MBX_PAIRS];
 	char message[KMAILBOX_MESSAGE_SIZE];
 
 	local = knode_get_num();
@@ -1319,14 +1298,14 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 		}
 	}
@@ -1334,12 +1313,12 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
@@ -1347,7 +1326,7 @@ PRIVATE void test_stress_mailbox_multiplexing_broadcast(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 		}
 	}
@@ -1364,7 +1343,7 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 {
 	int local;
 	int remote;
-	int mbxids[TEST_MAILBOX_NPORTS];
+	int mbxids[TEST_MULTIPLEXATION_MBX_PAIRS];
 	char message[KMAILBOX_MESSAGE_SIZE];
 
 	local = knode_get_num();
@@ -1376,14 +1355,14 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_open(remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 		}
 	}
@@ -1391,12 +1370,12 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert((mbxids[j] = kmailbox_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					message[0] = local;
 					test_assert(kmailbox_read(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
@@ -1404,7 +1383,7 @@ PRIVATE void test_stress_mailbox_multiplexing_gather(void)
 				}
 			}
 
-			for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+			for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 		}
 	}
@@ -1421,8 +1400,8 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 {
 	int local;
 	int remote;
-	int inboxes[TEST_MAILBOX_NPORTS];
-	int outboxes[TEST_MAILBOX_NPORTS];
+	int inboxes[TEST_MULTIPLEXATION_MBX_PAIRS];
+	int outboxes[TEST_MULTIPLEXATION_MBX_PAIRS];
 	char msg_in[KMAILBOX_MESSAGE_SIZE];
 	char msg_out[KMAILBOX_MESSAGE_SIZE];
 
@@ -1433,7 +1412,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert((inboxes[j] = kmailbox_create(local, j)) >= 0);
 			test_assert((outboxes[j] = kmailbox_open(remote, j)) >= 0);
@@ -1443,7 +1422,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kmailbox_read(inboxes[k], msg_in, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
@@ -1457,7 +1436,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_MAILBOX_NPORTS; ++k)
+				for (int k = 0; k < TEST_THREAD_NPORTS; ++k)
 				{
 					test_assert(kmailbox_write(outboxes[k], msg_out, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
@@ -1468,7 +1447,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
 			}
 		}
 
-		for (int j = 0; j < TEST_MAILBOX_NPORTS; ++j)
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
 		{
 			test_assert(kmailbox_close(outboxes[j]) == 0);
 			test_assert(kmailbox_unlink(inboxes[j]) == 0);
@@ -1539,12 +1518,6 @@ PRIVATE void fence(struct fence *b)
 		spinlock_unlock(&b->lock);
 	}
 }
-
-#ifdef __mppa256__
-	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_THREAD_NPORTS (THREAD_MAX)
-#endif
 
 /*============================================================================*
  * Stress Test: Mailbox Thread Multiplexing Broadcast                         *

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -214,7 +214,11 @@ static void test_api_mailbox_read_write(void)
  * API Test: Virtualization                                                   *
  *============================================================================*/
 
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+#define TEST_VIRTUALIZATION_MBX_NR KMAILBOX_PORT_NR
+#else
 #define TEST_VIRTUALIZATION_MBX_NR MAILBOX_PORT_NR
+#endif
 
 /**
  * @brief API Test: Virtualization.
@@ -248,7 +252,11 @@ static void test_api_mailbox_virtualization(void)
  * API Test: Multiplexation                                                   *
  *============================================================================*/
 
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+#define TEST_MULTIPLEXATION_MBX_PAIRS KMAILBOX_PORT_NR
+#else
 #define TEST_MULTIPLEXATION_MBX_PAIRS MAILBOX_PORT_NR
+#endif
 
 /**
  * @brief API Test: Multiplex of virtual to hardware mailboxes.
@@ -663,7 +671,12 @@ static void test_fault_mailbox_invalid_create(void)
 	test_assert(kmailbox_create(-1, 0) == -EINVAL);
 	test_assert(kmailbox_create(PROCESSOR_NOC_NODES_NUM, 0) == -EINVAL);
 	test_assert(kmailbox_create(nodenum, -1) == -EINVAL);
+
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	test_assert(kmailbox_create(nodenum, KMAILBOX_PORT_NR) == -EINVAL);
+#else
 	test_assert(kmailbox_create(nodenum, MAILBOX_PORT_NR) == -EINVAL);
+#endif
 }
 
 /*============================================================================*
@@ -774,7 +787,11 @@ static void test_fault_mailbox_invalid_open(void)
 	test_assert(kmailbox_open(-1, 0) == -EINVAL);
 	test_assert(kmailbox_open(PROCESSOR_NOC_NODES_NUM, 0) == -EINVAL);
 	test_assert(kmailbox_open(nodenum, -1) == -EINVAL);
+#if __NANVIX_IKC_USES_ONLY_MAILBOX
+	test_assert(kmailbox_open(nodenum, KMAILBOX_PORT_NR) == -EINVAL);
+#else
 	test_assert(kmailbox_open(nodenum, MAILBOX_PORT_NR) == -EINVAL);
+#endif
 }
 
 /*============================================================================*

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -89,10 +89,10 @@ static void test_api_mailbox_get_volume(void)
 	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
 	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
 
-		test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 		test_assert(volume == 0);
 
-		test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 		test_assert(volume == 0);
 
 	test_assert(kmailbox_close(mbx_out) == 0);
@@ -120,13 +120,65 @@ static void test_api_mailbox_get_latency(void)
 	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
 	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
 
-		test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency == 0);
 
-		test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+		test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency == 0);
 
 	test_assert(kmailbox_close(mbx_out) == 0);
+	test_assert(kmailbox_unlink(mbx_in) == 0);
+}
+
+/*============================================================================*
+ * API Test: Get counters                                                     *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Mailbox Get latency
+ */
+static void test_api_mailbox_get_counters(void)
+{
+	int local;
+	int remote;
+	int mbx_in;
+	int mbx_out;
+	uint64_t c0;
+	uint64_t c1;
+
+	local = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
+
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NCREATES, &c0) == 0);
+		test_assert(c0 == 4);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NOPENS, &c1) == 0);
+		test_assert(c1 == 3);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NCLOSES, &c1) == 0);
+		test_assert(c1 == 3);
+
+	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
+
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NCREATES, &c0) == 0);
+		test_assert(c0 == 4);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NOPENS, &c0) == 0);
+		test_assert(c0 == 4);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NUNLINKS, &c1) == 0);
+		test_assert(c1 == 3);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NCLOSES, &c1) == 0);
+		test_assert(c1 == 3);
+
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NREADS, &c1) == 0);
+		test_assert(c1 == 0);
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NWRITES, &c1) == 0);
+		test_assert(c1 == 0);
+
+	test_assert(kmailbox_close(mbx_out) == 0);
+
+		test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NCLOSES, &c1) == 0);
+		test_assert(c1 == 4);
+
 	test_assert(kmailbox_unlink(mbx_in) == 0);
 }
 
@@ -145,6 +197,7 @@ static void test_api_mailbox_read_write(void)
 	int mbx_out;
 	size_t volume;
 	uint64_t latency;
+	uint64_t counter;
 	char message[KMAILBOX_MESSAGE_SIZE];
 
 	local  = knode_get_num();
@@ -153,15 +206,20 @@ static void test_api_mailbox_read_write(void)
 	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
 	test_assert((mbx_out = kmailbox_open(remote, 0)) >= 0);
 
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == 0);
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency == 0);
 
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == 0);
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency == 0);
+
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NREADS, &counter) == 0);
+	test_assert(counter  == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NWRITES, &counter) == 0);
+	test_assert(counter == 0);
 
 	if (local == MASTER_NODENUM)
 	{
@@ -196,15 +254,20 @@ static void test_api_mailbox_read_write(void)
 		}
 	}
 
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == (NITERATIONS * KMAILBOX_MESSAGE_SIZE));
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == (NITERATIONS * KMAILBOX_MESSAGE_SIZE));
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
+
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NREADS, &counter) == 0);
+	test_assert(counter  == NITERATIONS);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_NWRITES, &counter) == 0);
+	test_assert(counter == NITERATIONS);
 
 	test_assert(kmailbox_close(mbx_out) == 0);
 	test_assert(kmailbox_unlink(mbx_in) == 0);
@@ -318,14 +381,14 @@ static void test_api_mailbox_multiplexation(void)
 	/* Checks the data volume transferred by each vmailbox. */
 	for (unsigned i = 0; i < TEST_MULTIPLEXATION_MBX_PAIRS; ++i)
 	{
-		test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(kmailbox_ioctl(mbx_in[i], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
-		test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+		test_assert(kmailbox_ioctl(mbx_in[i], KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 
-		test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
-		test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+		test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 	}
 
@@ -378,9 +441,9 @@ static void test_api_mailbox_multiplexation_2(void)
 
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_MBX_PAIRS; ++i)
 		{
-			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
-			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 		}
 	}
@@ -398,7 +461,7 @@ static void test_api_mailbox_multiplexation_2(void)
 
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_MBX_PAIRS; ++i)
 		{
-			test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(kmailbox_ioctl(mbx_in[i], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
 		}
 	}
@@ -465,9 +528,9 @@ static void test_api_mailbox_multiplexation_3(void)
 		/* Checks the data volume transfered by each mailbox. */
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_MBX_PAIRS; ++i)
 		{
-			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
-			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 		}
 	}
@@ -491,7 +554,7 @@ static void test_api_mailbox_multiplexation_3(void)
 		/* Checks the data volume transfered by each mailbox. */
 		for (unsigned i = 0; i < 2; ++i)
 		{
-			test_assert(kmailbox_ioctl(mbx_in[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(kmailbox_ioctl(mbx_in[i], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 			test_assert(volume == (KMAILBOX_MESSAGE_SIZE * 2));
 		}
 	}
@@ -551,9 +614,9 @@ static void test_api_mailbox_pending_msg_unlink(void)
 		/* Checks the data volume transfered by each mailbox. */
 		for (unsigned i = 0; i < TEST_PENDING_UNLINK_MBX_PAIRS; ++i)
 		{
-			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 			test_assert(volume == KMAILBOX_MESSAGE_SIZE);
-			test_assert(kmailbox_ioctl(mbx_out[i], MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(kmailbox_ioctl(mbx_out[i], KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 
 			test_assert(kmailbox_close(mbx_out[i]) == 0);
@@ -563,7 +626,7 @@ static void test_api_mailbox_pending_msg_unlink(void)
 	{
 		test_assert(kmailbox_read(mbx_in[1], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-		test_assert(kmailbox_ioctl(mbx_in[1], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(kmailbox_ioctl(mbx_in[1], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
 
 		test_assert(kmailbox_unlink(mbx_in[1]) == 0);
@@ -573,7 +636,7 @@ static void test_api_mailbox_pending_msg_unlink(void)
 
 		test_assert(kmailbox_read(mbx_in[0], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-		test_assert(kmailbox_ioctl(mbx_in[0], MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+		test_assert(kmailbox_ioctl(mbx_in[0], KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 		test_assert(volume == KMAILBOX_MESSAGE_SIZE);
 
 		test_assert(kmailbox_unlink(mbx_in[0]) == 0);
@@ -615,14 +678,14 @@ static void test_api_mailbox_msg_forwarding(void)
 	test_assert((mbx_in = kmailbox_create(local, 0)) >= 0);
 	test_assert((mbx_out = kmailbox_open(local, 0)) >= 0);
 
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == 0);
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency == 0);
 
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == 0);
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency == 0);
 
 	for (unsigned i = 0; i < NITERATIONS; i++)
@@ -639,14 +702,14 @@ static void test_api_mailbox_msg_forwarding(void)
 			test_assert(message[j] == local);
 	}
 
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == (NITERATIONS * KMAILBOX_MESSAGE_SIZE));
-	test_assert(kmailbox_ioctl(mbx_in, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_in, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_VOLUME, &volume) == 0);
 	test_assert(volume == (NITERATIONS * KMAILBOX_MESSAGE_SIZE));
-	test_assert(kmailbox_ioctl(mbx_out, MAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
+	test_assert(kmailbox_ioctl(mbx_out, KMAILBOX_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
 	test_assert(kmailbox_close(mbx_out) == 0);
@@ -1042,16 +1105,18 @@ static void test_fault_mailbox_invalid_ioctl(void)
 	size_t volume;
 	uint64_t latency;
 
-	test_assert(kmailbox_ioctl(-1, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EINVAL);
-	test_assert(kmailbox_ioctl(-1, MAILBOX_IOCTL_GET_LATENCY, &latency) == -EINVAL);
-	test_assert(kmailbox_ioctl(KMAILBOX_MAX, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EINVAL);
-	test_assert(kmailbox_ioctl(KMAILBOX_MAX, MAILBOX_IOCTL_GET_LATENCY, &latency) == -EINVAL);
+	test_assert(kmailbox_ioctl(-1, KMAILBOX_IOCTL_GET_VOLUME, &volume) == -EINVAL);
+	test_assert(kmailbox_ioctl(-1, KMAILBOX_IOCTL_GET_LATENCY, &latency) == -EINVAL);
+	test_assert(kmailbox_ioctl(KMAILBOX_MAX, KMAILBOX_IOCTL_GET_VOLUME, &volume) == -EINVAL);
+	test_assert(kmailbox_ioctl(KMAILBOX_MAX, KMAILBOX_IOCTL_GET_LATENCY, &latency) == -EINVAL);
 
 	local = knode_get_num();
 
 	test_assert((mbxid = kmailbox_create(local, 0)) >= 0);
 
 		test_assert(kmailbox_ioctl(mbxid, -1, &volume) == -ENOTSUP);
+		test_assert(kmailbox_ioctl(mbxid, KMAILBOX_IOCTL_GET_VOLUME, NULL) == -EFAULT);
+		test_assert(kmailbox_ioctl(mbxid, KMAILBOX_IOCTL_GET_LATENCY, NULL) == -EFAULT);
 
 	test_assert(kmailbox_unlink(mbxid) == 0);
 }
@@ -1085,7 +1150,7 @@ static void test_fault_mailbox_bad_mbxid(void)
 	test_assert(kmailbox_write(mbx_out + 1, buffer, KMAILBOX_MESSAGE_SIZE) == -EBADF);
 
 	test_assert(kmailbox_wait(mbx_out + 1) == -EBADF);
-	test_assert(kmailbox_ioctl(mbx_out + 1, MAILBOX_IOCTL_GET_VOLUME, &volume) == -EBADF);
+	test_assert(kmailbox_ioctl(mbx_out + 1, KMAILBOX_IOCTL_GET_VOLUME, &volume) == -EBADF);
 
 	test_assert(kmailbox_unlink(mbx_in + 1) == -EBADF);
 	test_assert(kmailbox_close(mbx_out + 1) == -EBADF);
@@ -2065,6 +2130,7 @@ static struct test mailbox_tests_api[] = {
 	{ test_api_mailbox_open_close,         "[test][mailbox][api] mailbox open close         [passed]" },
 	{ test_api_mailbox_get_volume,         "[test][mailbox][api] mailbox get volume         [passed]" },
 	{ test_api_mailbox_get_latency,        "[test][mailbox][api] mailbox get latency        [passed]" },
+	{ test_api_mailbox_get_counters,       "[test][mailbox][api] mailbox get counters       [passed]" },
 	{ test_api_mailbox_read_write,         "[test][mailbox][api] mailbox read write         [passed]" },
 	{ test_api_mailbox_virtualization,     "[test][mailbox][api] mailbox virtualization     [passed]" },
 	{ test_api_mailbox_multiplexation,     "[test][mailbox][api] mailbox multiplexation     [passed]" },

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -1893,7 +1893,6 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 					test_assert(kportal_allow(portalids[k], remote, (tid + k * THREAD_MAX)) >= 0);
 					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
-
 				}
 
 				fence(&_fence);
@@ -2356,6 +2355,8 @@ void test_portal(void)
 		for (unsigned i = 0; portal_tests_stress[i].test_fn != NULL; i++)
 		{
 			portal_tests_stress[i].test_fn();
+
+			barrier_nodes();
 
 			if (local == MASTER_NODENUM)
 				nanvix_puts(portal_tests_stress[i].name);

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -1260,8 +1260,7 @@ static void test_fault_portal_invalid_ioctl(void)
  */
 static void test_fault_portal_bad_portalid(void)
 {
-	int portal_in;
-	int portal_out;
+	int portal;
 	int remote;
 	int local;
 	size_t volume;
@@ -1270,19 +1269,15 @@ static void test_fault_portal_bad_portalid(void)
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
-	test_assert((portal_in = kportal_create(local, 0)) >= 0);
-	test_assert((portal_out = kportal_open(local, remote, 0)) >= 0);
+	portal = 0;
 
-	test_assert(kportal_close(portal_out + 1) == -EBADF);
-	test_assert(kportal_unlink(portal_in + 1) == -EBADF);
-	test_assert(kportal_allow(portal_in + 1, remote, 0) == -EBADF)
-	test_assert(kportal_read(portal_in + 1, buffer, MESSAGE_SIZE) == -EBADF);
-	test_assert(kportal_write(portal_in + 1, buffer, MESSAGE_SIZE) == -EBADF);
-	test_assert(kportal_wait(portal_in + 1) == -EBADF);
-	test_assert(kportal_ioctl(portal_in + 1, KPORTAL_IOCTL_GET_VOLUME, &volume) == -EBADF);
-
-	test_assert(kportal_close(portal_out) == 0);
-	test_assert(kportal_unlink(portal_in) == 0);
+	test_assert(kportal_close(portal) == -EBADF);
+	test_assert(kportal_unlink(portal) == -EBADF);
+	test_assert(kportal_allow(portal, remote, 0) == -EBADF)
+	test_assert(kportal_read(portal, buffer, MESSAGE_SIZE) == -EBADF);
+	test_assert(kportal_write(portal, buffer, MESSAGE_SIZE) == -EBADF);
+	test_assert(kportal_wait(portal) == -EBADF);
+	test_assert(kportal_ioctl(portal, KPORTAL_IOCTL_GET_VOLUME, &volume) == -EBADF);
 }
 
 /*============================================================================*

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -31,19 +31,6 @@
 
 #if __TARGET_HAS_PORTAL
 
-/**
- * @brief Test's parameters
- */
-#define NR_NODES       2
-#define NR_NODES_MAX   PROCESSOR_NOC_NODES_NUM
-#define MESSAGE_SIZE   1024
-#define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-#else
-	#define SLAVE_NODENUM  1
-#endif
-
 /*============================================================================*
  * API Test: Create Unlink                                                    *
  *============================================================================*/
@@ -165,7 +152,7 @@ static void test_api_portal_read_write(void)
 	int portal_out;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -187,44 +174,44 @@ static void test_api_portal_read_write(void)
 	{
 		for (unsigned i = 0; i < NITERATIONS; i++)
 		{
-			kmemset(message, 0, MESSAGE_SIZE);
+			kmemset(message, 0, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in, remote, 0) == 0);
-			test_assert(kportal_read(portal_in, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert(message[j] == 1);
 
-			kmemset(message, 2, MESSAGE_SIZE);
+			kmemset(message, 2, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out, message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 	}
 	else
 	{
 		for (unsigned i = 0; i < NITERATIONS; i++)
 		{
-			kmemset(message, 1, MESSAGE_SIZE);
+			kmemset(message, 1, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			kmemset(message, 0, MESSAGE_SIZE);
+			kmemset(message, 0, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in, remote, 0) == 0);
-			test_assert(kportal_read(portal_in, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert(message[j] == 2);
 		}
 	}
 
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
@@ -286,7 +273,7 @@ static void test_api_portal_multiplexation(void)
 	int portal_out[TEST_MULTIPLEXATION_PORTAL_PAIRS];
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -303,33 +290,33 @@ static void test_api_portal_multiplexation(void)
 	{
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++i)
 		{
-			kmemset(message, (i - 1), MESSAGE_SIZE);
+			kmemset(message, (i - 1), PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, i) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - i) == 0);
 
-			kmemset(message, (i + 1), MESSAGE_SIZE);
+			kmemset(message, (i + 1), PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 	}
 	else
 	{
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, i) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - i - 1) == 0);
 		}
 	}
@@ -338,12 +325,12 @@ static void test_api_portal_multiplexation(void)
 	for (unsigned i = 0; i < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++i)
 	{
 		test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 		test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 
 		test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 		test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 		test_assert(latency > 0);
 
@@ -366,7 +353,7 @@ static void test_api_portal_allow(void)
 	int remote;
 	int portal_in[2];
 	int portal_out[2];
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -378,7 +365,7 @@ static void test_api_portal_allow(void)
 
 		for (unsigned i = 0; i < 2; ++i)
 		{
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_close(portal_out[i]) == 0);
 		}
@@ -391,12 +378,12 @@ static void test_api_portal_allow(void)
 
 		/* Allowing tests. */
 		test_assert(kportal_allow(portal_in[0], remote, 0) == 0);
-		test_assert(kportal_read(portal_in[1], message, MESSAGE_SIZE) == -EACCES);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == MESSAGE_SIZE);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == -EACCES);
+		test_assert(kportal_read(portal_in[1], message, PORTAL_SIZE) == -EACCES);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == PORTAL_SIZE);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == -EACCES);
 		test_assert(kportal_allow(portal_in[1], remote, 1) == 0);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == -EACCES);
-		test_assert(kportal_read(portal_in[1], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == -EACCES);
+		test_assert(kportal_read(portal_in[1], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		/* Unlinks the created vportals. */
 		for (unsigned i = 0; i < 2; ++i)
@@ -422,7 +409,7 @@ static void test_api_portal_multiplexation_2(void)
 	int portal_out[TEST_MULTIPLEXATION2_PORTAL_PAIRS];
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -439,17 +426,17 @@ static void test_api_portal_multiplexation_2(void)
 		/* Read the messages in descendant order. */
 		for (int i = (TEST_MULTIPLEXATION2_PORTAL_PAIRS - 1); i >= 0; --i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, i) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - i) == 0);
 
 			/* Checks the data transfered by each vportal. */
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 		}
@@ -458,12 +445,12 @@ static void test_api_portal_multiplexation_2(void)
 	{
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_PORTAL_PAIRS; ++i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 		}
@@ -501,7 +488,7 @@ static void test_api_portal_multiplexation_3(void)
 	int port;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -515,16 +502,16 @@ static void test_api_portal_multiplexation_3(void)
 		/* Sends all the messages to the SLAVE node. */
 		for (int i = (TEST_MULTIPLEXATION3_PORTAL_MSGS_NR - 1); i >= 0; --i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 
 		/* Closes the opened vportals. */
 		for (unsigned int i = 0; i < TEST_MULTIPLEXATION3_PORTAL_MSGS_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 
 			test_assert(kportal_close(portal_out[i]) == 0);
 		}
@@ -539,12 +526,12 @@ static void test_api_portal_multiplexation_3(void)
 		{
 			port = kcomm_get_port(portal_in[i], COMM_TYPE_PORTAL);
 
-			kmemset(message, -1, MESSAGE_SIZE);
+			kmemset(message, -1, PORTAL_SIZE);
 
 			test_assert(kportal_allow(portal_in[i], remote, port) == 0);
-			test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+			for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 				test_assert((message[j] - port) == 0);
 		}
 
@@ -552,7 +539,7 @@ static void test_api_portal_multiplexation_3(void)
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_PORTAL_SELECT_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 
@@ -588,7 +575,7 @@ static void test_api_portal_multiplexation_4(void)
 	int port;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -607,13 +594,13 @@ static void test_api_portal_multiplexation_4(void)
 			{
 				port = (i*2 + j);
 
-				kmemset(message, -1, MESSAGE_SIZE);
+				kmemset(message, -1, PORTAL_SIZE);
 
 				test_assert(kportal_allow(portal_in[i], remote, port) == 0);
-				test_assert(kportal_read(portal_in[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+				test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				/* Asserts the message data. */
-				for (unsigned k = 0; k < MESSAGE_SIZE; ++k)
+				for (unsigned k = 0; k < PORTAL_SIZE; ++k)
 					test_assert((message[k] - port) == 0);
 			}
 		}
@@ -622,7 +609,7 @@ static void test_api_portal_multiplexation_4(void)
 		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SELECT_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == (MESSAGE_SIZE * TEST_MLTPX4_PORTAL_SELECT_MSG));
+			test_assert(volume == (PORTAL_SIZE * TEST_MLTPX4_PORTAL_SELECT_MSG));
 			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 
@@ -639,16 +626,16 @@ static void test_api_portal_multiplexation_4(void)
 		/* Sends all the messages to the MASTER node. */
 		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SEND_NR; ++i)
 		{
-			kmemset(message, i, MESSAGE_SIZE);
+			kmemset(message, i, PORTAL_SIZE);
 
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 		}
 
 		/* Checks the data volume transferred by each vportal. */
 		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SEND_NR; ++i)
 		{
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 
 			/* Closes the output vportals. */
 			test_assert(kportal_close(portal_out[i]) == 0);
@@ -677,7 +664,7 @@ static void test_api_portal_pending_msg_unlink(void)
 	uint64_t latency;
 	int portal_in[TEST_PENDING_UNLINK_PORTAL_PAIRS];
 	int portal_out[TEST_PENDING_UNLINK_PORTAL_PAIRS];
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local  = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -689,13 +676,13 @@ static void test_api_portal_pending_msg_unlink(void)
 			test_assert((portal_out[i] = kportal_open(local, remote, i)) >= 0);
 
 		for (int i = 0; i < TEST_PENDING_UNLINK_PORTAL_PAIRS; ++i)
-			test_assert(kportal_write(portal_out[i], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		/* Checks the data volume transfered by each vportal. */
 		for (unsigned i = 0; i < TEST_PENDING_UNLINK_PORTAL_PAIRS; ++i)
 		{
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-			test_assert(volume == MESSAGE_SIZE);
+			test_assert(volume == PORTAL_SIZE);
 			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 			test_assert(latency > 0);
 
@@ -711,10 +698,10 @@ static void test_api_portal_pending_msg_unlink(void)
 
 		/* Unlink tests. */
 		test_assert(kportal_allow(portal_in[1], remote, 1) == 0);
-		test_assert(kportal_read(portal_in[1], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in[1], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		test_assert(kportal_ioctl(portal_in[1], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 
 		test_assert(kportal_unlink(portal_in[1]) == 0);
 
@@ -722,10 +709,10 @@ static void test_api_portal_pending_msg_unlink(void)
 		test_assert(kportal_unlink(portal_in[0]) == -EBUSY);
 
 		test_assert(kportal_allow(portal_in[0], remote, 0) == 0);
-		test_assert(kportal_read(portal_in[0], message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in[0], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 		test_assert(kportal_ioctl(portal_in[0], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-		test_assert(volume == MESSAGE_SIZE);
+		test_assert(volume == PORTAL_SIZE);
 
 		test_assert(kportal_unlink(portal_in[0]) == 0);
 	}
@@ -745,7 +732,7 @@ static void test_api_portal_msg_forwarding(void)
 	int portal_out;
 	size_t volume;
 	uint64_t latency;
-	char message[MESSAGE_SIZE];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 
@@ -766,25 +753,25 @@ static void test_api_portal_msg_forwarding(void)
 	{
 		test_assert(kportal_allow(portal_in, local, 0) == 0);
 
-		kmemset(message, local, MESSAGE_SIZE);
+		kmemset(message, local, PORTAL_SIZE);
 
-		test_assert(kportal_write(portal_out, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_write(portal_out, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-		kmemset(message, -1, MESSAGE_SIZE);
+		kmemset(message, -1, PORTAL_SIZE);
 
-		test_assert(kportal_read(portal_in, message, MESSAGE_SIZE) == MESSAGE_SIZE);
+		test_assert(kportal_read(portal_in, message, PORTAL_SIZE) == PORTAL_SIZE);
 
-		for (unsigned j = 0; j < MESSAGE_SIZE; ++j)
+		for (unsigned j = 0; j < PORTAL_SIZE; ++j)
 			test_assert(message[j] == local);
 	}
 
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_in, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
-	test_assert(volume == (NITERATIONS * MESSAGE_SIZE));
+	test_assert(volume == (NITERATIONS * PORTAL_SIZE));
 	test_assert(kportal_ioctl(portal_out, KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
 	test_assert(latency > 0);
 
@@ -1049,10 +1036,10 @@ static void test_fault_portal_bad_allow(void)
  */
 static void test_fault_portal_invalid_read(void)
 {
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
-	test_assert(kportal_read(-1, buffer, MESSAGE_SIZE) == -EINVAL);
-	test_assert(kportal_read(KPORTAL_MAX, buffer, MESSAGE_SIZE) == -EINVAL);
+	test_assert(kportal_read(-1, buffer, PORTAL_SIZE) == -EINVAL);
+	test_assert(kportal_read(KPORTAL_MAX, buffer, PORTAL_SIZE) == -EINVAL);
 }
 
 /*============================================================================*
@@ -1067,14 +1054,14 @@ static void test_fault_portal_bad_read(void)
 	int local;
 	int remote;
 	int portalid;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
 
 	test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
-	test_assert(kportal_read(portalid, buffer, MESSAGE_SIZE) == -EBADF);
+	test_assert(kportal_read(portalid, buffer, PORTAL_SIZE) == -EBADF);
 
 	test_assert(kportal_close(portalid) == 0);
 }
@@ -1090,7 +1077,7 @@ static void test_fault_portal_invalid_read_size(void)
 {
 	int portalid;
 	int local;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 
@@ -1119,7 +1106,7 @@ static void test_fault_portal_null_read(void)
 
 	test_assert((portalid = kportal_create(local, 0)) >= 0);
 
-		test_assert(kportal_read(portalid, NULL, MESSAGE_SIZE) == -EINVAL);
+		test_assert(kportal_read(portalid, NULL, PORTAL_SIZE) == -EINVAL);
 
 	test_assert(kportal_unlink(portalid) == 0);
 }
@@ -1133,10 +1120,10 @@ static void test_fault_portal_null_read(void)
  */
 static void test_fault_portal_invalid_write(void)
 {
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
-	test_assert(kportal_write(-1, buffer, MESSAGE_SIZE) == -EINVAL);
-	test_assert(kportal_write(KPORTAL_MAX, buffer, MESSAGE_SIZE) == -EINVAL);
+	test_assert(kportal_write(-1, buffer, PORTAL_SIZE) == -EINVAL);
+	test_assert(kportal_write(KPORTAL_MAX, buffer, PORTAL_SIZE) == -EINVAL);
 }
 
 /*============================================================================*
@@ -1150,13 +1137,13 @@ static void test_fault_portal_bad_write(void)
 {
 	int local;
 	int portalid;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 
 	test_assert((portalid = kportal_create(local, 0)) >= 0);
 
-		test_assert(kportal_write(portalid, buffer, MESSAGE_SIZE) == -EBADF);
+		test_assert(kportal_write(portalid, buffer, PORTAL_SIZE) == -EBADF);
 
 	test_assert(kportal_unlink(portalid) == 0);
 }
@@ -1173,7 +1160,7 @@ static void test_fault_portal_invalid_write_size(void)
 	int local;
 	int remote;
 	int portalid;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1205,7 +1192,7 @@ static void test_fault_portal_null_write(void)
 
 	test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
-		test_assert(kportal_write(portalid, NULL, MESSAGE_SIZE) == -EINVAL);
+		test_assert(kportal_write(portalid, NULL, PORTAL_SIZE) == -EINVAL);
 
 	test_assert(kportal_close(portalid) == 0);
 }
@@ -1264,7 +1251,7 @@ static void test_fault_portal_bad_portalid(void)
 	int remote;
 	int local;
 	size_t volume;
-	char buffer[MESSAGE_SIZE];
+	char buffer[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1274,8 +1261,8 @@ static void test_fault_portal_bad_portalid(void)
 	test_assert(kportal_close(portal) == -EBADF);
 	test_assert(kportal_unlink(portal) == -EBADF);
 	test_assert(kportal_allow(portal, remote, 0) == -EBADF)
-	test_assert(kportal_read(portal, buffer, MESSAGE_SIZE) == -EBADF);
-	test_assert(kportal_write(portal, buffer, MESSAGE_SIZE) == -EBADF);
+	test_assert(kportal_read(portal, buffer, PORTAL_SIZE) == -EBADF);
+	test_assert(kportal_write(portal, buffer, PORTAL_SIZE) == -EBADF);
 	test_assert(kportal_wait(portal) == -EBADF);
 	test_assert(kportal_ioctl(portal, KPORTAL_IOCTL_GET_VOLUME, &volume) == -EBADF);
 }
@@ -1283,16 +1270,6 @@ static void test_fault_portal_bad_portalid(void)
 /*============================================================================*
  * Stress Tests                                                               *
  *============================================================================*/
-
-/**
- * @name Number of setups and communications.
- */
-/**@{*/
-#define NSETUPS 1
-#define NCOMMUNICATIONS 1
-#define TEST_PORTAL_SIZE 512
-#define TEST_PORTAL_NPORTS TEST_MULTIPLEXATION_PORTAL_PAIRS
-/**@}*/
 
 /*============================================================================*
  * Stress Test: Portal Create Unlink                                          *
@@ -1350,7 +1327,7 @@ PRIVATE void test_stress_portal_broadcast(void)
 	int local;
 	int remote;
 	int portalid;
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 	
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1364,7 +1341,7 @@ PRIVATE void test_stress_portal_broadcast(void)
 			test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				test_assert(kportal_write(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_close(portalid) == 0);
 		}
@@ -1379,7 +1356,7 @@ PRIVATE void test_stress_portal_broadcast(void)
 			{
 				message[0] = local;
 				test_assert(kportal_allow(portalid, remote, 0) >= 0);
-				test_assert(kportal_read(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(message[0] == remote);
 			}
 
@@ -1400,7 +1377,7 @@ PRIVATE void test_stress_portal_gather(void)
 	int local;
 	int remote;
 	int portalid;
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1414,7 +1391,7 @@ PRIVATE void test_stress_portal_gather(void)
 			test_assert((portalid = kportal_open(local, remote, 0)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				test_assert(kportal_write(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 
 			test_assert(kportal_close(portalid) == 0);
 		}
@@ -1429,7 +1406,7 @@ PRIVATE void test_stress_portal_gather(void)
 			{
 				message[0] = local;
 				test_assert(kportal_allow(portalid, remote, 0) >= 0);
-				test_assert(kportal_read(portalid, message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(portalid, message, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(message[0] == remote);
 			}
 
@@ -1451,8 +1428,8 @@ PRIVATE void test_stress_portal_pingpong(void)
 	int remote;
 	int inportal;
 	int outportal;
-	char msg_in[TEST_PORTAL_SIZE];
-	char msg_out[TEST_PORTAL_SIZE];
+	char msg_in[PORTAL_SIZE];
+	char msg_out[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1470,21 +1447,21 @@ PRIVATE void test_stress_portal_pingpong(void)
 			{
 				msg_in[0] = local;
 				test_assert(kportal_allow(inportal, remote, 0) >= 0);
-				test_assert(kportal_read(inportal, msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(inportal, msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(msg_in[0] == remote);
 
-				test_assert(kportal_write(outportal, msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(outportal, msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 			}
 		}
 		else
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				test_assert(kportal_write(outportal, msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_write(outportal, msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 
 				msg_in[0] = local;
 				test_assert(kportal_allow(inportal, remote, 0) >= 0);
-				test_assert(kportal_read(inportal, msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				test_assert(kportal_read(inportal, msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 				test_assert(msg_in[0] == remote);
 			}
 		}
@@ -1505,8 +1482,8 @@ PRIVATE void test_stress_portal_multiplexing_broadcast(void)
 {
 	int local;
 	int remote;
-	int portalids[TEST_PORTAL_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	int portalids[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1517,14 +1494,14 @@ PRIVATE void test_stress_portal_multiplexing_broadcast(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_close(portalids[j]) == 0);
 		}
 	}
@@ -1532,21 +1509,21 @@ PRIVATE void test_stress_portal_multiplexing_broadcast(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, k) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 				}
 			}
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 		}
 	}
@@ -1563,8 +1540,8 @@ PRIVATE void test_stress_portal_multiplexing_gather(void)
 {
 	int local;
 	int remote;
-	int portalids[TEST_PORTAL_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	int portalids[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	char message[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1575,14 +1552,14 @@ PRIVATE void test_stress_portal_multiplexing_gather(void)
 
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_open(local, remote, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_close(portalids[j]) == 0);
 		}
 	}
@@ -1590,21 +1567,21 @@ PRIVATE void test_stress_portal_multiplexing_gather(void)
 	{
 		for (int i = 0; i < NSETUPS; ++i)
 		{
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert((portalids[j] = kportal_create(local, j)) >= 0);
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, k) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 				}
 			}
 
-			for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+			for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 		}
 	}
@@ -1621,10 +1598,10 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 {
 	int local;
 	int remote;
-	int inportals[TEST_PORTAL_NPORTS];
-	int outportals[TEST_PORTAL_NPORTS];
-	PRIVATE char msg_in[TEST_PORTAL_SIZE];
-	PRIVATE char msg_out[TEST_PORTAL_SIZE];
+	int inportals[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	int outportals[TEST_MULTIPLEXATION_PORTAL_PAIRS];
+	PRIVATE char msg_in[PORTAL_SIZE];
+	PRIVATE char msg_out[PORTAL_SIZE];
 
 	local = knode_get_num();
 	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
@@ -1633,7 +1610,7 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 
 	for (int i = 0; i < NSETUPS; ++i)
 	{
-		for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+		for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 		{
 			test_assert((inportals[j] = kportal_create(local, j)) >= 0);
 			test_assert((outportals[j] = kportal_open(local, remote, j)) >= 0);
@@ -1643,14 +1620,14 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, k) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 			}
 		}
@@ -1658,19 +1635,19 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
 		{
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
-				for (int k = 0; k < TEST_PORTAL_NPORTS; ++k)
+				for (int k = 0; k < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++k)
 				{
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, k) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 				}
 			}
 		}
 
-		for (int j = 0; j < TEST_PORTAL_NPORTS; ++j)
+		for (int j = 0; j < TEST_MULTIPLEXATION_PORTAL_PAIRS; ++j)
 		{
 			test_assert(kportal_close(outportals[j]) == 0);
 			test_assert(kportal_unlink(inportals[j]) == 0);
@@ -1742,12 +1719,6 @@ PRIVATE void fence(struct fence *b)
 	}
 }
 
-#ifdef __mppa256__
-	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define TEST_THREAD_NPORTS (THREAD_MAX)
-#endif
-
 /*============================================================================*
  * Stress Test: Portal Thread Multiplexing Broadcast                          *
  *============================================================================*/
@@ -1759,7 +1730,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 	int remote;
 	int nports;
 	int portalids[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -1784,7 +1755,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -1814,7 +1785,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 				}
 
@@ -1865,7 +1836,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 	int local;
 	int remote;
 	int portalids[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -1890,7 +1861,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -1920,7 +1891,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 				{
 					message[0] = local;
 					test_assert(kportal_allow(portalids[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == remote);
 
 				}
@@ -1973,8 +1944,8 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 	int nports;
 	int inportals[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
 	int outportals[(TEST_THREAD_NPORTS / THREAD_MAX) + 1];
-	char msg_in[TEST_PORTAL_SIZE];
-	char msg_out[TEST_PORTAL_SIZE];
+	char msg_in[PORTAL_SIZE];
+	char msg_out[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -2006,10 +1977,10 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 				{
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
 				fence(&_fence);
@@ -2021,11 +1992,11 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 			{
 				for (int k = 0; k < nports; ++k)
 				{
-					test_assert(kportal_write(outportals[k], msg_out, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(outportals[k], msg_out, PORTAL_SIZE) == PORTAL_SIZE);
 
 					msg_in[0] = local;
 					test_assert(kportal_allow(inportals[k], remote, (tid + k * THREAD_MAX)) >= 0);
-					test_assert(kportal_read(inportals[k], msg_in, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(inportals[k], msg_in, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(msg_in[0] == remote);
 				}
 
@@ -2075,7 +2046,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 	int local;
 	int nports;
 	int portalids[TEST_THREAD_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -2098,7 +2069,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -2128,7 +2099,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				{
 					message[0] = 0;
 					test_assert(kportal_allow(portalids[k], local, ((tid - 1) + k * (THREAD_MAX - 1))) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == 1);
 				}
 
@@ -2178,7 +2149,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 	int local;
 	int nports;
 	int portalids[TEST_THREAD_NPORTS];
-	char message[TEST_PORTAL_SIZE];
+	char message[PORTAL_SIZE];
 
 	tid = ((int)(intptr_t) arg);
 
@@ -2202,7 +2173,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
 			{
 				for (int k = 0; k < nports; ++k)
-					test_assert(kportal_write(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_write(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 
 				fence(&_fence);
 			}
@@ -2231,7 +2202,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				{
 					message[0] = 0;
 					test_assert(kportal_allow(portalids[k], local, k) >= 0);
-					test_assert(kportal_read(portalids[k], message, TEST_PORTAL_SIZE) == TEST_PORTAL_SIZE);
+					test_assert(kportal_read(portalids[k], message, PORTAL_SIZE) == PORTAL_SIZE);
 					test_assert(message[0] == 1);
 
 				}

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -537,7 +537,7 @@ static void test_api_portal_multiplexation_3(void)
 
 		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_PORTAL_SELECT_NR; ++i)
 		{
-			port = portal_in[i] % KPORTAL_PORT_NR;
+			port = kcomm_get_port(portal_in[i], COMM_TYPE_PORTAL);
 
 			kmemset(message, -1, MESSAGE_SIZE);
 

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -720,6 +720,240 @@ static void test_api_portal_multiplexation_4(void)
 	}
 }
 
+/**
+ * @brief API Test: Multiplexation test to assert the correct working when
+ * messages flow occur in diferent order than the expected.
+ */
+static void test_api_portal_multiplexation_2_large(void)
+{
+	int local;
+	int remote;
+	int portal_in[TEST_MULTIPLEXATION2_PORTAL_PAIRS];
+	int portal_out[TEST_MULTIPLEXATION2_PORTAL_PAIRS];
+	size_t volume;
+	uint64_t latency;
+
+	local  = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	/* Creates multiple virtual portals. */
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION2_PORTAL_PAIRS; ++i)
+	{
+		test_assert((portal_in[i] = kportal_create(local, i)) >= 0);
+		test_assert((portal_out[i] = kportal_open(local, remote, i)) >= 0);
+	}
+
+	if (local == MASTER_NODENUM)
+	{
+		/* Read the messages in descendant order. */
+		for (int i = (TEST_MULTIPLEXATION2_PORTAL_PAIRS - 1); i >= 0; --i)
+		{
+			kmemset(message, i, PORTAL_SIZE_LARGE);
+
+			test_assert(kportal_allow(portal_in[i], remote, i) == 0);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE_LARGE) == PORTAL_SIZE_LARGE);
+
+			for (unsigned j = 0; j < PORTAL_SIZE_LARGE; ++j)
+				test_assert((message[j] - i) == 0);
+
+			/* Checks the data transfered by each vportal. */
+			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == PORTAL_SIZE_LARGE);
+			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(latency > 0);
+		}
+	}
+	else
+	{
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION2_PORTAL_PAIRS; ++i)
+		{
+			kmemset(message, i, PORTAL_SIZE_LARGE);
+
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE_LARGE) == PORTAL_SIZE_LARGE);
+
+			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == PORTAL_SIZE_LARGE);
+			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(latency > 0);
+		}
+	}
+
+	/* Deletion of the created virtual portals. */
+	for (unsigned i = 0; i < TEST_MULTIPLEXATION2_PORTAL_PAIRS; ++i)
+	{
+		test_assert(kportal_unlink(portal_in[i]) == 0);
+		test_assert(kportal_close(portal_out[i]) == 0);
+	}
+}
+
+/*============================================================================*
+ * API Test: Multiplexation - Messages Selection                              *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Multiplexation test to assert the correct message selection
+ * of multiple messages.
+ *
+ * @details In this test, the MASTER node sends 4 messages but only 2 for open ports
+ * on the SLAVE which need to select them correctly.
+ */
+static void test_api_portal_multiplexation_3_large(void)
+{
+	int local;
+	int remote;
+	int portal_in[TEST_MULTIPLEXATION3_PORTAL_SELECT_NR];
+	int portal_out[TEST_MULTIPLEXATION3_PORTAL_MSGS_NR];
+	int port;
+	size_t volume;
+	uint64_t latency;
+
+	local  = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	if (local == SLAVE_NODENUM)
+	{
+		/* Opens the output vportals. */
+		for (unsigned int i = 0; i < TEST_MULTIPLEXATION3_PORTAL_MSGS_NR; ++i)
+			test_assert((portal_out[i] = kportal_open(local, remote, i)) >= 0);
+
+		/* Sends all the messages to the SLAVE node. */
+		for (int i = (TEST_MULTIPLEXATION3_PORTAL_MSGS_NR - 1); i >= 0; --i)
+		{
+			kmemset(message, i, PORTAL_SIZE_LARGE);
+
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE_LARGE) == PORTAL_SIZE_LARGE);
+		}
+
+		/* Closes the opened vportals. */
+		for (unsigned int i = 0; i < TEST_MULTIPLEXATION3_PORTAL_MSGS_NR; ++i)
+		{
+			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == PORTAL_SIZE_LARGE);
+
+			test_assert(kportal_close(portal_out[i]) == 0);
+		}
+	}
+	else
+	{
+		/* Creates multiple virtual portals (half of the MASTER senders). */
+		for (int i = 0; i < TEST_MULTIPLEXATION3_PORTAL_SELECT_NR; ++i)
+			test_assert((portal_in[i] = kportal_create(local, (i*2))) >= 0);
+
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_PORTAL_SELECT_NR; ++i)
+		{
+			port = kcomm_get_port(portal_in[i], COMM_TYPE_PORTAL);
+
+			kmemset(message, -1, PORTAL_SIZE_LARGE);
+
+			test_assert(kportal_allow(portal_in[i], remote, port) == 0);
+			test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE_LARGE) == PORTAL_SIZE_LARGE);
+
+			for (unsigned j = 0; j < PORTAL_SIZE_LARGE; ++j)
+				test_assert((message[j] - port) == 0);
+		}
+
+		/* Checks the data volume transferred by each vportal. */
+		for (unsigned i = 0; i < TEST_MULTIPLEXATION3_PORTAL_SELECT_NR; ++i)
+		{
+			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == PORTAL_SIZE_LARGE);
+			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(latency > 0);
+
+			/* Unlinks each vportal. */
+			test_assert(kportal_unlink(portal_in[i]) == 0);
+		}
+	}
+}
+
+/*============================================================================*
+ * API Test: Multiplexation - Multiple Messages                               *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Multiplexation test to assert the message buffers tab
+ * solution to support multiple messages on the same port simultaneously.
+ *
+ * @details In this test, the SLAVE sends 4 messages to 2 ports of the SLAVE.
+ * The reads in the master are also made out of order to assure that there are
+ * 2 messages queued for each vportal on MASTER.
+ */
+static void test_api_portal_multiplexation_4_large(void)
+{
+	int local;
+	int remote;
+	int portal_in[TEST_MLTPX4_PORTAL_SELECT_NR];
+	int portal_out[TEST_MLTPX4_PORTAL_SEND_NR];
+	int port;
+	size_t volume;
+	uint64_t latency;
+
+	local  = knode_get_num();
+	remote = (local == MASTER_NODENUM) ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	if (local == MASTER_NODENUM)
+	{
+		/* Creates multiple virtual portals. */
+		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SELECT_NR; ++i)
+			test_assert((portal_in[i] = kportal_create(local, i)) >= 0);
+
+		/* For each input vportal. */
+		for (int i = (TEST_MLTPX4_PORTAL_SELECT_NR - 1); i >= 0; --i)
+		{
+			/* For each message it should receive. */
+			for (int j = (TEST_MLTPX4_PORTAL_SELECT_MSG - 1); j >= 0; --j)
+			{
+				port = (i*2 + j);
+
+				kmemset(message, -1, PORTAL_SIZE_LARGE);
+
+				test_assert(kportal_allow(portal_in[i], remote, port) == 0);
+				test_assert(kportal_read(portal_in[i], message, PORTAL_SIZE_LARGE) == PORTAL_SIZE_LARGE);
+
+				/* Asserts the message data. */
+				for (unsigned k = 0; k < PORTAL_SIZE_LARGE; ++k)
+					test_assert((message[k] - port) == 0);
+			}
+		}
+
+		/* Checks the data volume transferred by each vportal. */
+		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SELECT_NR; ++i)
+		{
+			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == (PORTAL_SIZE_LARGE * TEST_MLTPX4_PORTAL_SELECT_MSG));
+			test_assert(kportal_ioctl(portal_in[i], KPORTAL_IOCTL_GET_LATENCY, &latency) == 0);
+			test_assert(latency > 0);
+
+			/* Unlinks the created vportals. */
+			test_assert(kportal_unlink(portal_in[i]) == 0);
+		}
+	}
+	else
+	{
+		/* Opens the output vportals. */
+		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SEND_NR; ++i)
+			test_assert((portal_out[i] = kportal_open(local, remote, (int) (i/TEST_MLTPX4_PORTAL_SELECT_MSG))) >= 0);
+
+		/* Sends all the messages to the MASTER node. */
+		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SEND_NR; ++i)
+		{
+			kmemset(message, i, PORTAL_SIZE_LARGE);
+
+			test_assert(kportal_write(portal_out[i], message, PORTAL_SIZE_LARGE) == PORTAL_SIZE_LARGE);
+		}
+
+		/* Checks the data volume transferred by each vportal. */
+		for (unsigned i = 0; i < TEST_MLTPX4_PORTAL_SEND_NR; ++i)
+		{
+			test_assert(kportal_ioctl(portal_out[i], KPORTAL_IOCTL_GET_VOLUME, &volume) == 0);
+			test_assert(volume == PORTAL_SIZE_LARGE);
+
+			/* Closes the output vportals. */
+			test_assert(kportal_close(portal_out[i]) == 0);
+		}
+	}
+}
+
 /*============================================================================*
  * API Test: Pending Messages - Unlink                                        *
  *============================================================================*/
@@ -2176,21 +2410,24 @@ PRIVATE void test_stress_portal_thread_multiplexing_gather_local(void)
  * @brief API tests.
  */
 static struct test portal_tests_api[] = {
-	{ test_api_portal_create_unlink,      "[test][portal][api] portal create unlink      [passed]" },
-	{ test_api_portal_open_close,         "[test][portal][api] portal open close         [passed]" },
-	{ test_api_portal_get_volume,         "[test][portal][api] portal get volume         [passed]" },
-	{ test_api_portal_get_latency,        "[test][portal][api] portal get latency        [passed]" },
-	{ test_api_portal_read_write,         "[test][portal][api] portal read write         [passed]" },
-	{ test_api_portal_read_write_large,   "[test][portal][api] portal read write large   [passed]" },
-	{ test_api_portal_virtualization,     "[test][portal][api] portal virtualization     [passed]" },
-	{ test_api_portal_multiplexation,     "[test][portal][api] portal multiplexation     [passed]" },
-	{ test_api_portal_allow,              "[test][portal][api] portal allow              [passed]" },
-	{ test_api_portal_multiplexation_2,   "[test][portal][api] portal multiplexation 2   [passed]" },
-	{ test_api_portal_multiplexation_3,   "[test][portal][api] portal multiplexation 3   [passed]" },
-	{ test_api_portal_multiplexation_4,   "[test][portal][api] portal multiplexation 4   [passed]" },
-	{ test_api_portal_pending_msg_unlink, "[test][portal][api] portal pending msg unlink [passed]" },
-	{ test_api_portal_msg_forwarding,     "[test][portal][api] portal message forwarding [passed]" },
-	{ NULL,                                NULL                                                    },
+	{ test_api_portal_create_unlink,          "[test][portal][api] portal create unlink          [passed]" },
+	{ test_api_portal_open_close,             "[test][portal][api] portal open close             [passed]" },
+	{ test_api_portal_get_volume,             "[test][portal][api] portal get volume             [passed]" },
+	{ test_api_portal_get_latency,            "[test][portal][api] portal get latency            [passed]" },
+	{ test_api_portal_read_write,             "[test][portal][api] portal read write             [passed]" },
+	{ test_api_portal_read_write_large,       "[test][portal][api] portal read write large       [passed]" },
+	{ test_api_portal_virtualization,         "[test][portal][api] portal virtualization         [passed]" },
+	{ test_api_portal_multiplexation,         "[test][portal][api] portal multiplexation         [passed]" },
+	{ test_api_portal_allow,                  "[test][portal][api] portal allow                  [passed]" },
+	{ test_api_portal_multiplexation_2,       "[test][portal][api] portal multiplexation 2       [passed]" },
+	{ test_api_portal_multiplexation_3,       "[test][portal][api] portal multiplexation 3       [passed]" },
+	{ test_api_portal_multiplexation_4,       "[test][portal][api] portal multiplexation 4       [passed]" },
+	{ test_api_portal_multiplexation_2_large, "[test][portal][api] portal multiplexation 2 Large [passed]" },
+	{ test_api_portal_multiplexation_3_large, "[test][portal][api] portal multiplexation 3 Large [passed]" },
+	{ test_api_portal_multiplexation_4_large, "[test][portal][api] portal multiplexation 4 Large [passed]" },
+	{ test_api_portal_pending_msg_unlink,     "[test][portal][api] portal pending msg unlink     [passed]" },
+	{ test_api_portal_msg_forwarding,         "[test][portal][api] portal message forwarding     [passed]" },
+	{ NULL,                                    NULL                                                        },
 };
 
 /**
@@ -2264,7 +2501,7 @@ void test_portal(void)
 		{
 			portal_tests_api[i].test_fn();
 
-			// if (local == MASTER_NODENUM)
+			if (local == MASTER_NODENUM)
 				nanvix_puts(portal_tests_api[i].name);
 		}
 

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -104,6 +104,9 @@ void ___start(int argc, const char *argv[])
 	int index;
 	int nodenum;
 
+	/* Required. */
+	knoc_init();
+
 	((void) argc);
 	((void) argv);
 

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -133,46 +133,46 @@ void ___start(int argc, const char *argv[])
 		#ifndef __unix64__
 			test_perf();
 			test_signal();
-		#endif
+		#endif /* __unix64__ */
 
 			test_noc();
 		}
 
 		#if __TARGET_HAS_SYNC
 			test_sync();
-		#endif
 
-		/**
-		 * Creates a barrier with all involved clusters.
-		 * Note (valid only if multiplexation is not avaiable):
-		 * the stdsync must be cleanup before call the barruer_setup
-		 * because it uses the same local resources.
-		 */
-		barrier_nodes_setup(_nodenums, NR_NODES, (index == 0));
+			/**
+			* Creates a barrier with all involved clusters.
+			* Note (valid only if multiplexation is not avaiable):
+			* the stdsync must be cleanup before call the barruer_setup
+			* because it uses the same local resources.
+			*/
+			barrier_nodes_setup(_nodenums, NR_NODES, (index == 0));
 
-			barrier_nodes();
+				barrier_nodes();
 
-			#if __TARGET_HAS_MAILBOX
-				test_mailbox();
-			#endif
+				#if __TARGET_HAS_MAILBOX
+					test_mailbox();
+				#endif
 
-			barrier_nodes();
+				barrier_nodes();
 
-			#if __TARGET_HAS_PORTAL
-				test_portal();
-			#endif
+				#if __TARGET_HAS_PORTAL
+					test_portal();
+				#endif
 
-			barrier_nodes();
+				barrier_nodes();
 
-			#if __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL
-				test_ikc();
-			#endif
+				#if __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL
+					test_ikc();
+				#endif
 
-			/* Waits everyone finishes the routines. */
-			barrier_nodes();
+				/* Waits everyone finishes the routines. */
+				barrier_nodes();
 
-		/* Destroy barrier. */
-		barrier_nodes_cleanup();
+			/* Destroy barrier. */
+			barrier_nodes_cleanup();
+		#endif /* __TARGET_HAS_SYNC */
 	}
 
 	/* Halt. */

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -65,7 +65,7 @@
 	/**
 	 * @brief Number of iterations in stress tests.
 	 */
-	#define NITERATIONS 10
+	#define NITERATIONS 1000
 
 	/**
 	 * @brief Number of threads to spawn in stress tests.

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -28,6 +28,41 @@
 	#include <nanvix/sys/thread.h>
 
 	/**
+     * @brief Test's parameters
+     */
+    #define NR_NODES       2
+    #define MASTER_NODENUM 0
+    #ifdef __mppa256__
+        #define SLAVE_NODENUM  8
+    #else
+        #define SLAVE_NODENUM  1
+    #endif
+
+    #ifdef __mppa256__
+        #define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
+    #else
+        #define TEST_THREAD_NPORTS (THREAD_MAX)
+    #endif
+
+    #define NSETUPS 10
+    #define NCOMMUNICATIONS 100
+
+    /**
+     * @brief Portal message size
+     */
+    #define PORTAL_SIZE (1 * KB)
+
+	/**
+     * @brief Portal message size
+     */
+    #define MAILBOX_SIZE (KMAILBOX_MESSAGE_SIZE)
+
+    /**
+     * @brief Max number of nodes involved.
+     */
+    #define MAX_NUM_NODES PROCESSOR_NOC_NODES_NUM
+
+	/**
 	 * @brief Number of iterations in stress tests.
 	 */
 	#define NITERATIONS 10
@@ -91,5 +126,10 @@
 			kshutdown() /* noop */;                   \
 		}                                             \
 	}
+
+	/**
+     * @brief Horizontal line.
+     */
+    extern const char *HLINE;
 
 #endif /* _TEST_H_  */

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -91,6 +91,15 @@
 	 */
 	extern void nanvix_puts(const char *str);
 
+    /**
+     * @name Barrier functions
+     */
+    /**@{*/
+    extern void barrier_nodes_setup(const int * nodes, int nnodes, int is_master);
+    extern void barrier_nodes(void);
+    extern void barrier_nodes_cleanup(void);
+    /**@}*/
+
 	/**
 	 * @name User-Level Testing Units
 	 */

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -91,6 +91,7 @@
 	 */
 	extern void nanvix_puts(const char *str);
 
+#if __TARGET_HAS_SYNC
     /**
      * @name Barrier functions
      */
@@ -99,6 +100,7 @@
     extern void barrier_nodes(void);
     extern void barrier_nodes_cleanup(void);
     /**@}*/
+#endif /* __TARGET_HAS_SYNC */
 
 	/**
 	 * @name User-Level Testing Units

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -48,8 +48,8 @@
      * @name Portal sizes.
      */
 	/**@{*/
-    #define PORTAL_SIZE       (1 * KB)                            /**< Small size. */
-	#define PORTAL_SIZE_LARGE (HAL_PORTAL_MAX_SIZE + PORTAL_SIZE) /**< Large size. */
+    #define PORTAL_SIZE       (1 * KB)                             /**< Small size. */
+	#define PORTAL_SIZE_LARGE (HAL_PORTAL_DATA_SIZE + PORTAL_SIZE) /**< Large size. */
 	/**@}*/
 
 	/**

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -30,27 +30,27 @@
 	/**
      * @brief Test's parameters
      */
+	/**@{*/
     #define NR_NODES       2
     #define MASTER_NODENUM 0
-    #ifdef __mppa256__
-        #define SLAVE_NODENUM  8
-    #else
-        #define SLAVE_NODENUM  1
-    #endif
-
-    #ifdef __mppa256__
-        #define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-    #else
-        #define TEST_THREAD_NPORTS (THREAD_MAX)
-    #endif
-
+#ifdef __mppa256__
+	#define SLAVE_NODENUM  8
+	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
+#else
+	#define SLAVE_NODENUM  1
+	#define TEST_THREAD_NPORTS (THREAD_MAX)
+#endif
     #define NSETUPS 10
     #define NCOMMUNICATIONS 100
+	/**@}*/
 
     /**
-     * @brief Portal message size
+     * @name Portal sizes.
      */
-    #define PORTAL_SIZE (1 * KB)
+	/**@{*/
+    #define PORTAL_SIZE       (1 * KB)                            /**< Small size. */
+	#define PORTAL_SIZE_LARGE (HAL_PORTAL_MAX_SIZE + PORTAL_SIZE) /**< Large size. */
+	/**@}*/
 
 	/**
      * @brief Portal message size


### PR DESCRIPTION
## Description

In this PR, I introduce counters to the sync table to keep the number of signals a sync point received from a cluster. This avoids dropping signals.


## Solved Issue

[[ikc] Unnecessary dropping of signals in the Sync module (Mailbox Implementation) #40](https://github.com/nanvix/libnanvix/issues/40)

## Related Submodule PR

[Enhancement: Update HAL](https://github.com/nanvix/microkernel/pull/259)