### PR TITLE
[ikc] Limited but stable version of the Portal on Mailbox

### DIFF
--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -301,7 +301,7 @@ ssize_t kmailbox_write(int mbxid, const void * buffer, size_t size)
 	if ((size == 0) || (size > KMAILBOX_MESSAGE_SIZE))
 		return (-EINVAL);
 
-	if ((ret = kmailbox_awrite(mbxid, buffer, size)) < 0)
+	if ((ret = kmailbox_awrite(mbxid, buffer, size)) < 1)
 		return (ret);
 
 	if ((ret = kmailbox_wait(mbxid)) < 0)


### PR DESCRIPTION
In this PR, I fix some weird behaviors of Portal on ONLY_MAILBOX mode. But that solution does not support `IKC thread multiplexing ping-pong reverse` test. The limitation is specified by #49.

## Related issue (not resolved)

[[ikc] Current ONLY_MAILBOX mode does not support IKC thread multiplexing ping-pong reverse test #49](https://github.com/nanvix/libnanvix/issues/49)