### PR TITLE
Update Microkernel

### DIFF
--- a/img/qemu-openrisc.img
+++ b/img/qemu-openrisc.img
@@ -1,1 +1,1 @@
-tests-driver.qemu-openrisc
+libnanvix-tests.qemu-openrisc


### PR DESCRIPTION
In this PR, I update Microkernel to get the fixes of nested interrupts bug.
Also, I fix binary names in openrisc image.


## Related Submodule Pull Request

[[mppa256] Bugfix: Update HAL to remove nested interrupts bug](https://github.com/nanvix/microkernel/pull/267)