### PR TITLE
[pm] Transferred Thread Fence from Tests to Nanvix Library

### DIFF
--- a/include/nanvix/runtime/fence.h
+++ b/include/nanvix/runtime/fence.h
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_RUNTIME_FENCE_H_
+#define NANVIX_RUNTIME_FENCE_H_
+
+	#include <nanvix/sys/mutex.h>
+
+	/**
+	 * @brief Fence
+	 */
+	struct fence_t
+	{
+		int ncores;               /**< Number of cores in the fence.           */
+		int nreached;             /**< Number of cores that reached the fence. */
+		int release;              /**< Wait condition.                         */
+		struct nanvix_mutex lock; /**< Lock.                                   */
+	};
+
+	/**
+	 * @brief Initializes a fence.
+	 *
+	 * @param b      Target fence.
+ 	 * @param ncores Number of cores in the fence.
+	 *
+	 * @returns Upons sucessful completion zero is returned. Upon failure,
+	 * a negative number is returned instead.
+	 */
+	extern void fence_init(struct fence_t *b, int ncores);
+
+	/**
+	 * @brief Waits in a fence until the defined number of threads reach it.
+	 *
+	 * @param b Target fence.
+	 *
+	 * @returns Upon sucessful completion, zero is returned. Upon failure a
+	 * negative errorcode is returned instead.
+	 */
+	extern void fence(struct fence_t *b);
+
+#endif /* NANVIX_RUNTIME_FENCE_H_ */

--- a/src/libnanvix/thread/fence.c
+++ b/src/libnanvix/thread/fence.c
@@ -22,20 +22,13 @@
  * SOFTWARE.
  */
 
-#include <nanvix/sys/sync.h>
-#include <nanvix/sys/mutex.h>
+#include <nanvix/runtime/fence.h>
 #include <posix/errno.h>
-#include "test.h"
-
-#if (__TARGET_HAS_SYNC)
 
 /**
- * @brief Initializes a fence.
- *
- * @param b      Target fence.
- * @param ncores Number of cores in the fence.
+ * @see fence_init() in nanvix/runtime/fence.h
  */
-PUBLIC void fence_init(struct fence *b, int ncores)
+PUBLIC void fence_init(struct fence_t *b, int ncores)
 {
 	b->ncores   = ncores;
 	b->nreached = 0;
@@ -44,9 +37,9 @@ PUBLIC void fence_init(struct fence *b, int ncores)
 }
 
 /**
- * @brief Waits in a fence.
+ * @see fence() in nanvix/runtime/fence.h
  */
-PUBLIC void fence(struct fence *b)
+PUBLIC void fence(struct fence_t *b)
 {
 	int exit;
 	int local_release;
@@ -73,5 +66,3 @@ PUBLIC void fence(struct fence *b)
 		nanvix_mutex_unlock(&b->lock);
 	} while (!exit);
 }
-
-#endif /* __TARGET_HAS_SYNC */

--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -27,6 +27,7 @@
 #include <nanvix/sys/mailbox.h>
 #include <nanvix/sys/portal.h>
 #include <nanvix/sys/noc.h>
+#include <nanvix/runtime/fence.h>
 #include <posix/errno.h>
 
 #include "test.h"
@@ -51,7 +52,7 @@
  * Global variables                                                           *
  *============================================================================*/
 
-PRIVATE struct fence _fence;
+PRIVATE struct fence_t _fence;
 PRIVATE char message[PORTAL_SIZE_LARGE];
 PRIVATE char message_in[TEST_THREAD_MAX][PORTAL_SIZE];
 PRIVATE char message_out[PORTAL_SIZE];

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -26,6 +26,7 @@
 #include <nanvix/sys/thread.h>
 #include <nanvix/sys/mailbox.h>
 #include <nanvix/sys/noc.h>
+#include <nanvix/runtime/fence.h>
 #include <posix/errno.h>
 
 #include "test.h"
@@ -1550,7 +1551,7 @@ PRIVATE void test_stress_mailbox_multiplexing_pingpong(void)
  * Stress Test: Thread synchronization                                        *
  *============================================================================*/
 
-PRIVATE struct fence _fence;
+PRIVATE struct fence_t _fence;
 
 /*============================================================================*
  * Stress Test: Thread Specified Source                                       *

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -25,6 +25,7 @@
 
 #include <nanvix/sys/portal.h>
 #include <nanvix/sys/noc.h>
+#include <nanvix/runtime/fence.h>
 #include <posix/errno.h>
 
 #include "test.h"
@@ -1964,7 +1965,7 @@ PRIVATE void test_stress_portal_multiplexing_pingpong(void)
  * Stress Test: Thread synchronization                                        *
  *============================================================================*/
 
-PRIVATE struct fence _fence;
+PRIVATE struct fence_t _fence;
 
 /*============================================================================*
  * Stress Test: Portal Thread Multiplexing Broadcast                          *

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -104,21 +104,6 @@
     extern void test_barrier_nodes(void);
     extern void test_barrier_nodes_cleanup(void);
     /**@}*/
-
-    /**
-     * @name Fence
-     */
-    /**@{*/
-	struct fence
-	{
-		int ncores;               /**< Number of cores in the fence.           */
-		int nreached;             /**< Number of cores that reached the fence. */
-		int release;              /**< Wait condition.                         */
-		struct nanvix_mutex lock; /**< Lock.                                   */
-	};
-	extern void fence_init(struct fence *b, int ncores);
-	extern void fence(struct fence *b);
-    /**@}*/
 #endif /* __TARGET_HAS_SYNC */
 
 	/**


### PR DESCRIPTION
## Description ##
Passed the Threads FENCE definition from the tests directory to the Nanvix Library. It is intended to export the fence implementation for the above layers.