### PR TITLE
[ikc] Feature: Mailbox Set Remote

### DIFF
--- a/include/nanvix/sys/mailbox.h
+++ b/include/nanvix/sys/mailbox.h
@@ -164,6 +164,18 @@
 	 */
 	extern int kmailbox_ioctl(int, unsigned, ...);
 
+	/**
+	 * @brief Specifies the mailbox remote for a single read.
+	 *
+	 * @param mbxid  Target mailbox.
+	 * @param remote Remote node number.
+	 * @param port   Remote port number.
+	 *
+	 * @param Upon successful completion, zero is returned. Upon failure,
+	 * a negative error code is returned instead.
+	 */
+	extern int kmailbox_set_remote(int, int, int);
+
 #endif /* NANVIX_SYS_MAILBOX_H_ */
 
 /**@}*/

--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -477,6 +477,30 @@ error:
 }
 
 /*============================================================================*
+ * kmailbox_set_remote()                                                      *
+ *============================================================================*/
+
+/**
+ * @todo Provide a detailed description about this function.
+ */
+int kmailbox_set_remote(int mbxid, int remote, int remote_port)
+{
+	int ret;
+
+	/* Invalid nodenum. */
+	if (!WITHIN(remote, 0, (MAILBOX_ANY_SOURCE + 1)))
+		return (-EINVAL);
+
+	/* Invalid port number. */
+	if (!WITHIN(remote_port, 0, (MAILBOX_ANY_PORT + 1)))
+		return (-EINVAL);
+
+	ret = kmailbox_ioctl(mbxid, KMAILBOX_IOCTL_SET_REMOTE, remote, remote_port);
+
+	return (ret);
+}
+
+/*============================================================================*
  * kmailbox_init()                                                            *
  *============================================================================*/
 


### PR DESCRIPTION
# Description #
In this PR, we add to the IKC Mailbox interface the ```kmailbox_set_remote``` function, to be used instead of ```kmailbox_ioctl``` with the correct IOCTL opcode.
This modification comes to facilitate the operation usage and to keep the coding style clean when performing this functionality in the above layers.