### PR TITLE
[pm] Threads Fence

### DIFF
--- a/include/nanvix/runtime/fence.h
+++ b/include/nanvix/runtime/fence.h
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_RUNTIME_FENCE_H_
+#define NANVIX_RUNTIME_FENCE_H_
+
+	#include <nanvix/sys/mutex.h>
+
+	/**
+	 * @brief Fence
+	 */
+	struct fence_t
+	{
+		int ncores;      /**< Number of cores in the fence.           */
+		int nreached;    /**< Number of cores that reached the fence. */
+		int release;     /**< Wait condition.                         */
+		spinlock_t lock; /**< Lock.                                   */
+	};
+
+	/**
+	 * @brief Initializes a fence.
+	 *
+	 * @param b      Target fence.
+ 	 * @param ncores Number of cores in the fence.
+	 *
+	 * @returns Upons sucessful completion zero is returned. Upon failure,
+	 * a negative number is returned instead.
+	 */
+	extern void fence_init(struct fence_t *b, int ncores);
+
+	/**
+	 * @brief Waits in a fence until the defined number of threads reach it.
+	 *
+	 * @param b Target fence.
+	 *
+	 * @returns Upon sucessful completion, zero is returned. Upon failure a
+	 * negative errorcode is returned instead.
+	 */
+	extern void fence(struct fence_t *b);
+
+#endif /* NANVIX_RUNTIME_FENCE_H_ */

--- a/src/libnanvix/thread/fence.c
+++ b/src/libnanvix/thread/fence.c
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/runtime/fence.h>
+#include <posix/errno.h>
+
+/**
+ * @see fence_init() in nanvix/runtime/fence.h
+ */
+PUBLIC void fence_init(struct fence_t *b, int ncores)
+{
+	b->ncores   = ncores;
+	b->nreached = 0;
+	b->release  = 0;
+	spinlock_init(&b->lock);
+}
+
+/**
+ * @see fence() in nanvix/runtime/fence.h
+ */
+PUBLIC void fence(struct fence_t *b)
+{
+	int exit;
+	int local_release;
+
+	/* Notifies thread reach. */
+	spinlock_lock(&b->lock);
+
+		local_release = !b->release;
+
+		b->nreached++;
+
+		if (b->nreached == b->ncores)
+		{
+			b->nreached = 0;
+			b->release  = local_release;
+		}
+
+	spinlock_unlock(&b->lock);
+
+	do
+	{
+		spinlock_lock(&b->lock);
+			exit = (local_release == b->release);
+		spinlock_unlock(&b->lock);
+	} while (!exit);
+}

--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -23,10 +23,10 @@
  * SOFTWARE.
  */
 
-#include <nanvix/sys/thread.h>
 #include <nanvix/sys/mailbox.h>
 #include <nanvix/sys/portal.h>
 #include <nanvix/sys/noc.h>
+#include <nanvix/runtime/fence.h>
 #include <posix/errno.h>
 
 #include "test.h"
@@ -34,7 +34,7 @@
 #if __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL
 
 /*============================================================================*
- * Contants                                                                   *
+ * Constants                                                                  *
  *============================================================================*/
 
 /**
@@ -52,6 +52,11 @@
 PRIVATE char message[PORTAL_SIZE_LARGE];
 PRIVATE char message_in[TEST_THREAD_MAX][PORTAL_SIZE];
 PRIVATE char message_out[PORTAL_SIZE];
+
+/**
+ * @brief Simple fence used for thread synchronization.
+ */
+PRIVATE struct fence_t _fence;
 
 /*============================================================================*
  * Stress Tests                                                               *
@@ -725,66 +730,6 @@ PRIVATE void test_stress_ikc_multiplexing_pingpong_reverse(void)
 /*============================================================================*
  * Stress Test: Thread synchronization                                        *
  *============================================================================*/
-
-/**
- * @brief A simple fence.
- */
-static struct fence
-{
-	int ncores;      /**< Number of cores in the fence.            */
-	int nreached;    /**< Number of cores that reached the fence.  */
-	int release;     /**< Wait condition.                          */
-	spinlock_t lock; /**< Lock.                                    */
-} _fence = {
-	0, 0, 0, SPINLOCK_UNLOCKED
-};
-
-/**
- * @brief Initializes a fence.
- *
- * @param b      Target fence.
- * @param ncores Number of cores in the fence.
- */
-PRIVATE void fence_init(struct fence *b, int ncores)
-{
-	b->ncores   = ncores;
-	b->nreached = 0;
-}
-
-/**
- * @brief Waits in a fence.
- */
-PRIVATE void fence(struct fence *b)
-{
-	int exit;
-	int local_release;
-
-	/* Notifies thread reach. */
-	spinlock_lock(&b->lock);
-
-		local_release = !b->release;
-
-		b->nreached++;
-
-		if (b->nreached == b->ncores)
-		{
-			b->nreached = 0;
-			b->release  = local_release;
-		}
-
-	spinlock_unlock(&b->lock);
-
-	exit = 0;
-	while (!exit)
-	{
-		exit = 100;
-		while (exit--);
-
-		spinlock_lock(&b->lock);
-			exit = (local_release == b->release);
-		spinlock_unlock(&b->lock);
-	}
-}
 
 /*============================================================================*
  * Stress Test: Portal Thread Multiplexing Broadcast                          *


### PR DESCRIPTION
# Description #
In this PR, we moved the Threads ```Fence``` implementation from the Libnanvix test files to an individual header file and its related implementation, this way, enabling this implementation to be exported and used in the above layers. 

# Related Issues #
- Closes #70 - [[pm] Export User Threads Fence to the above layers](https://github.com/nanvix/libnanvix/issues/70)

### Possibilities of Improvement ###
For now, this Fence is implemented using raw Spinlocks. One possibility of improvement is to implement this abstraction using Semaphores or Mutexes, which would result in better efficiency since threads waiting may sleep, instead of occupying the processor with busy waiting.