### PR TITLE
[pm] Synchronization Condvar Release Ordering in All Platforms

### DIFF
--- a/include/nanvix/sys/condvar.h
+++ b/include/nanvix/sys/condvar.h
@@ -43,11 +43,10 @@
 	struct nanvix_cond_var
 	{
 		spinlock_t lock;
-		#if (__NANVIX_CONDVAR_SLEEP)
-			kthread_t tids[THREAD_MAX];
-		#else
+		kthread_t tids[THREAD_MAX];
+
+		#if (!__NANVIX_CONDVAR_SLEEP)
 			bool locked;
-			int waiting;
 		#endif
 	};
 


### PR DESCRIPTION
In this PR, we guarantee that the `condvar` abstraction keeps the releasing order when releasing threads that were waiting in a synchronization point. 

## Related issue

Closes #75 