### PR TITLE
[ikc][bugfix] Communicators Get_Port

### DIFF
--- a/include/nanvix/sys/mailbox.h
+++ b/include/nanvix/sys/mailbox.h
@@ -176,6 +176,15 @@
 	 */
 	extern int kmailbox_set_remote(int, int, int);
 
+	/**
+	 * @brief Gets local port attached to a mailbox.
+	 *
+	 * @param mbxid Mailbox ID
+	 *
+	 * @returns Upon successful completion, local port attached to mbxid.
+	 */
+	extern int kmailbox_get_port(int);
+
 #endif /* NANVIX_SYS_MAILBOX_H_ */
 
 /**@}*/

--- a/include/nanvix/sys/portal.h
+++ b/include/nanvix/sys/portal.h
@@ -173,8 +173,6 @@
 	 */
 	extern int kportal_ioctl(int portalid, unsigned request, ...);
 
-#if __NANVIX_IKC_USES_ONLY_MAILBOX
-
 	/**
 	 * @brief Gets local port attached to a portal.
 	 *
@@ -183,8 +181,6 @@
 	 * @returns Upon successful completion, local port attached to portalid.
 	 */
 	extern int kportal_get_port(int portalid);
-
-#endif /* __NANVIX_IKC_USES_ONLY_MAILBOX */
 
 #endif /* NANVIX_SYS_PORTAL_H_ */
 

--- a/src/libnanvix/ikc/mailbox.c
+++ b/src/libnanvix/ikc/mailbox.c
@@ -25,14 +25,13 @@
 #define __NANVIX_MICROKERNEL
 
 #include <nanvix/kernel/kernel.h>
+#include <nanvix/sys/noc.h>
 
 #if __TARGET_HAS_MAILBOX
 
 #include <posix/errno.h>
 
 #if __NANVIX_IKC_USES_ONLY_MAILBOX
-
-#include <nanvix/sys/noc.h>
 
 /**
  * @brief Protections.
@@ -496,6 +495,26 @@ int kmailbox_set_remote(int mbxid, int remote, int remote_port)
 		return (-EINVAL);
 
 	ret = kmailbox_ioctl(mbxid, KMAILBOX_IOCTL_SET_REMOTE, remote, remote_port);
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kmailbox_get_port()                                                        *
+ *============================================================================*/
+
+/**
+ * @details Get port details.
+ */
+PUBLIC int kmailbox_get_port(int mbxid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
+		return (-EINVAL);
+
+	ret = kcomm_get_port(mbxid, COMM_TYPE_MAILBOX);
 
 	return (ret);
 }

--- a/src/libnanvix/ikc/portal.c
+++ b/src/libnanvix/ikc/portal.c
@@ -402,6 +402,26 @@ int kportal_ioctl(int portalid, unsigned request, ...)
 }
 
 /*============================================================================*
+ * kportal_get_port()                                                         *
+ *============================================================================*/
+
+/**
+ * @details Get port details.
+ */
+PUBLIC int kportal_get_port(int portalid)
+{
+	int ret; /* Return value. */
+
+	/* Invalid portalid. */
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	ret = kcomm_get_port(portalid, COMM_TYPE_PORTAL);
+
+	return (ret);
+}
+
+/*============================================================================*
  * kportal_init()                                                             *
  *============================================================================*/
 


### PR DESCRIPTION
# Description #
In this PR, we made the function ```get_port``` available for both Portal and Mailbox interfaces, in order to permit a service to retrieve the underlying port of a communicator. Additionally, we corrected the ```std_get_port``` routines when using the Standard IKC structures, which were inconsistent with the new thread system implemented in the underlying levels.