### PR TITLE
[thread] Sleep/wakeup Scheme on Mutex/Semaphore/Condvar

### DIFF
--- a/include/nanvix/sys/condvar.h
+++ b/include/nanvix/sys/condvar.h
@@ -105,7 +105,7 @@
 	 * @returns 0 upon successfull completion or a negative error code
 	 * upon failure.
 	 */
-	extern int nanvix_condvar_destroy(struct nanvix_cond_var *cond);
+	extern int nanvix_cond_destroy(struct nanvix_cond_var *cond);
 
 #endif  /* CORES_NUM */
 

--- a/include/nanvix/sys/condvar.h
+++ b/include/nanvix/sys/condvar.h
@@ -43,7 +43,12 @@
 	struct nanvix_cond_var
 	{
 		spinlock_t lock;
-		kthread_t tids[THREAD_MAX];
+		spinlock_t lock2;
+
+		int begin;                  /**< Fist valid element.    */
+		int end;                    /**< Last valid element.    */
+		int size;                   /**< Current queue size.    */
+		kthread_t tids[THREAD_MAX]; /**< Buffer.                */
 
 		#if (!__NANVIX_CONDVAR_SLEEP)
 			bool locked;

--- a/include/nanvix/sys/mutex.h
+++ b/include/nanvix/sys/mutex.h
@@ -63,7 +63,12 @@
 
 		#if (__NANVIX_MUTEX_SLEEP)
 
-			kthread_t tids[THREAD_MAX]; /**< Sleeping threads. */
+			int begin;                  /**< Fist valid element.    */
+			int end;                    /**< Last valid element.    */
+			int size;                   /**< Current queue size.    */
+			kthread_t tids[THREAD_MAX]; /**< Buffer.                */
+
+			spinlock_t lock2;           /**< Exclusive unlock call. */
 
 		#endif /* __NANVIX_MUTEX_SLEEP */
 	};

--- a/include/nanvix/sys/mutex.h
+++ b/include/nanvix/sys/mutex.h
@@ -41,6 +41,7 @@
 	#define NANVIX_MUTEX_ERRORCHECK 1
 	#define NANVIX_MUTEX_RECURSIVE  2
 	#define NANVIX_MUTEX_DEFAULT    3
+	#define NANVIX_MUTEX_LIMIT      4
 
 	/**
 	 * @brief Mutex Attribute

--- a/include/nanvix/sys/semaphore.h
+++ b/include/nanvix/sys/semaphore.h
@@ -46,7 +46,12 @@
 
 		#if (__NANVIX_SEMAPHORE_SLEEP)
 
-			kthread_t tids[THREAD_MAX]; /**< Sleeping threads. */
+			int begin;                  /**< Fist valid element.    */
+			int end;                    /**< Last valid element.    */
+			int size;                   /**< Current queue size.    */
+			kthread_t tids[THREAD_MAX]; /**< Buffer.                */
+
+			spinlock_t lock2;           /**< Exclusive unlock call. */
 
 		#endif /* __NANVIX_SEMAPHORE_SLEEP */
 	};

--- a/src/libnanvix/thread/mutex.c
+++ b/src/libnanvix/thread/mutex.c
@@ -40,7 +40,7 @@
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutex_init(struct nanvix_mutex *m, struct nanvix_mutexattr *mattr)
+PUBLIC int nanvix_mutex_init(struct nanvix_mutex * m, struct nanvix_mutexattr * mattr)
 {
 	/* Invalid mutex. */
 	if (m == NULL)
@@ -86,7 +86,7 @@ int nanvix_mutex_init(struct nanvix_mutex *m, struct nanvix_mutexattr *mattr)
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutex_lock(struct nanvix_mutex *m)
+PUBLIC int nanvix_mutex_lock(struct nanvix_mutex * m)
 {
 	kthread_t tid;
 
@@ -155,11 +155,12 @@ int nanvix_mutex_lock(struct nanvix_mutex *m)
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutex_trylock(struct nanvix_mutex *m)
+PUBLIC int nanvix_mutex_trylock(struct nanvix_mutex * m)
 {
 	int ret;
 	kthread_t tid;
 
+	/* Invalid mutex. */
 	if (!m)
 		return (-EINVAL);
 
@@ -206,9 +207,9 @@ int nanvix_mutex_trylock(struct nanvix_mutex *m)
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutex_unlock(struct nanvix_mutex *m)
+PUBLIC int nanvix_mutex_unlock(struct nanvix_mutex * m)
 {
-	int ret = -1;
+	int ret = -EINVAL;
 	kthread_t tid;
 
 	/* Invalid mutex. */
@@ -242,7 +243,7 @@ int nanvix_mutex_unlock(struct nanvix_mutex *m)
 			}
 
 			/* Some error or recursive option triggered. */
-			if (ret != -1)
+			if (ret != -EINVAL)
 				goto exit;
 
 			m->locked = false;
@@ -295,8 +296,9 @@ exit:
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutex_destroy(struct nanvix_mutex *m)
+PUBLIC int nanvix_mutex_destroy(struct nanvix_mutex * m)
 {
+	/* Invalid mutex. */
 	if (!m)
 		return (-EINVAL);
 
@@ -322,8 +324,9 @@ int nanvix_mutex_destroy(struct nanvix_mutex *m)
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutexattr_init(struct nanvix_mutexattr *mattr)
+PUBLIC int nanvix_mutexattr_init(struct nanvix_mutexattr * mattr)
 {
+	/* Invalid attr. */
 	if (!mattr)
 		return (-EINVAL);
 
@@ -344,8 +347,9 @@ int nanvix_mutexattr_init(struct nanvix_mutexattr *mattr)
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutexattr_destroy(struct nanvix_mutexattr *mattr)
+PUBLIC int nanvix_mutexattr_destroy(struct nanvix_mutexattr * mattr)
 {
+	/* Invalid attr. */
 	if (!mattr)
 		return (-EINVAL);
 
@@ -367,9 +371,14 @@ int nanvix_mutexattr_destroy(struct nanvix_mutexattr *mattr)
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutexattr_settype(struct nanvix_mutexattr* mattr, int type)
+PUBLIC int nanvix_mutexattr_settype(struct nanvix_mutexattr * mattr, int type)
 {
+	/* Invalid attr. */
 	if (!mattr)
+		return (-EINVAL);
+
+	/* Invalid type. */
+	if (!WITHIN(type, 0, NANVIX_MUTEX_LIMIT))
 		return (-EINVAL);
 
 	mattr->type = type;
@@ -389,7 +398,9 @@ int nanvix_mutexattr_settype(struct nanvix_mutexattr* mattr, int type)
  * @return Upon sucessful completion, zero is returned. Upon failure, a
  * negative error code is returned instead.
  */
-int nanvix_mutexattr_gettype(struct nanvix_mutexattr* mattr) {
+PUBLIC int nanvix_mutexattr_gettype(struct nanvix_mutexattr * mattr)
+{
+	/* Invalid attr. */
 	if (!mattr)
 		return (-EINVAL);
 
@@ -397,3 +408,4 @@ int nanvix_mutexattr_gettype(struct nanvix_mutexattr* mattr) {
 }
 
 #endif /* CORES_NUM > 1 */
+

--- a/src/libnanvix/thread/mutex.c
+++ b/src/libnanvix/thread/mutex.c
@@ -58,8 +58,14 @@ int nanvix_mutex_init(struct nanvix_mutex *m, struct nanvix_mutexattr *mattr)
 
 	#if (__NANVIX_MUTEX_SLEEP)
 
+		m->begin = 0;
+		m->end   = 0;
+		m->size  = 0;
+
 		for (int i = 0; i < THREAD_MAX; i++)
 			m->tids[i] = -1;
+
+		spinlock_init(&m->lock2);
 
 	#endif /* __NANVIX_MUTEX_SLEEP */
 
@@ -103,23 +109,6 @@ int nanvix_mutex_lock(struct nanvix_mutex *m)
 	{
 		spinlock_lock(&m->lock);
 
-			#if (__NANVIX_MUTEX_SLEEP)
-
-				/* Dequeue kernel thread. */
-				for (int i = 0; i < THREAD_MAX; i++)
-				{
-					if (UNLIKELY(m->tids[i] == tid))
-					{
-						for (int j = i; j < (THREAD_MAX - 1); j++)
-							m->tids[j] = m->tids[j + 1];
-						m->tids[THREAD_MAX - 1] = -1;
-
-						break;
-					}
-				}
-
-			#endif /* __NANVIX_MUTEX_SLEEP */
-
 			/* Lock. */
 			if (LIKELY(!m->locked))
 			{
@@ -133,15 +122,11 @@ int nanvix_mutex_lock(struct nanvix_mutex *m)
 
 			#if (__NANVIX_MUTEX_SLEEP)
 
-				/* Enqueue kernel thread. */
-				for (int i = 0; i < THREAD_MAX; i++)
-				{
-					if (m->tids[i] == -1)
-					{
-						m->tids[i] = tid;
-						break;
-					}
-				}
+				KASSERT(m->size < THREAD_MAX);
+
+				m->tids[m->end] = tid;
+				m->end          = (m->end + 1) % THREAD_MAX;
+				m->size++;
 
 			#endif /* __NANVIX_MUTEX_SLEEP */
 
@@ -152,6 +137,7 @@ int nanvix_mutex_lock(struct nanvix_mutex *m)
 			ksleep();
 
 		#endif /* __NANVIX_MUTEX_SLEEP */
+
 	} while (LIKELY(true));
 
 	return (0);
@@ -170,35 +156,41 @@ int nanvix_mutex_lock(struct nanvix_mutex *m)
  * negative error code is returned instead.
  */
 int nanvix_mutex_trylock(struct nanvix_mutex *m)
- {
+{
+	int ret;
 	kthread_t tid;
+
 	if (!m)
 		return (-EINVAL);
 
+	ret = (-EBUSY);
 	tid = kthread_self();
 
-	if (m->locked)
-	{
-		if (m->type == NANVIX_MUTEX_RECURSIVE && m->owner == tid)
-		{
-			spinlock_lock(&m->lock);
-			m->rlevel++;
-			spinlock_unlock(&m->lock);
-			return (0);
-		}
-	}
-	else
-	{
-		spinlock_lock(&m->lock);
-		if (m->type == NANVIX_MUTEX_RECURSIVE)
-			m->rlevel++;
-		m->owner = tid;
-		m->locked = true;
-		spinlock_unlock(&m->lock);
-		return (0);
-	}
+	spinlock_lock(&m->lock);
 
-	return (-EBUSY);
+		/* Locked? */
+		if (m->locked)
+		{
+			if (m->type == NANVIX_MUTEX_RECURSIVE && m->owner == tid)
+			{
+				m->rlevel++;
+				ret = (0);
+			}
+		}
+
+		/* Not reserved? */
+		else
+		{
+			if (m->type == NANVIX_MUTEX_RECURSIVE)
+				m->rlevel++;
+			m->owner  = tid;
+			m->locked = true;
+			ret = (0);
+		}
+
+	spinlock_unlock(&m->lock);
+
+	return (ret);
  }
 
 
@@ -216,64 +208,79 @@ int nanvix_mutex_trylock(struct nanvix_mutex *m)
  */
 int nanvix_mutex_unlock(struct nanvix_mutex *m)
 {
+	int ret = -1;
 	kthread_t tid;
+
 	/* Invalid mutex. */
 	if (UNLIKELY(m == NULL))
 		return (-EINVAL);
 
 	tid = kthread_self();
 
-	if (m->type == NANVIX_MUTEX_ERRORCHECK)
-	{
-		if (!m->locked)
-			return (-EPERM);
-		if (m->owner != tid)
-			return (-EPERM);
-	}
-	else if (m->type == NANVIX_MUTEX_RECURSIVE)
-	{
-		if (m->rlevel > 0 && m->owner == tid)
-		{
-			spinlock_lock(&m->lock);
-			m->rlevel--;
-			if (m->rlevel != 0)
+#if (__NANVIX_MUTEX_SLEEP)
+	int head = -1;
+	spinlock_lock(&m->lock2);
+#endif
+
+		spinlock_lock(&m->lock);
+
+			if (m->type == NANVIX_MUTEX_ERRORCHECK)
 			{
-				spinlock_unlock(&m->lock);
-				return (0);
+				if (!m->locked || m->owner != tid)
+					ret = (-EPERM);
 			}
-			spinlock_unlock(&m->lock);
-		}
-		else
-			return (-EPERM);
-	}
+			else if (m->type == NANVIX_MUTEX_RECURSIVE)
+			{
+				if (m->rlevel > 0 && m->owner == tid)
+				{
+					m->rlevel--;
+					if (m->rlevel != 0)
+						ret = (0);
+				}
+				else
+					ret = (-EPERM);
+			}
+
+			/* Some error or recursive option triggered. */
+			if (ret != -1)
+				goto exit;
+
+			m->locked = false;
+			m->owner  = -1;
 
 #if (__NANVIX_MUTEX_SLEEP)
-
-again:
-
-#endif /* __NANVIX_MUTEX_SLEEP */
-
-	spinlock_lock(&m->lock);
-
-		#if (__NANVIX_MUTEX_SLEEP)
-
-			/* Dequeue thread. */
-			if (m->tids[0] != -1)
+			/**
+			 * Remove the head of the queue.
+			 */
+			if (m->size > 0)
 			{
-				if (UNLIKELY(kwakeup(m->tids[0]) != 0))
-				{
-					spinlock_unlock(&m->lock);
-					goto again;
-				}
+
+				head     = m->tids[m->begin];
+				m->begin = (m->begin + 1) % THREAD_MAX;
+				m->size--;
 			}
+#endif
 
-		#endif /* __NANVIX_MUTEX_SLEEP */
+			/* Success.*/
+			ret = (0);
+exit:
+		spinlock_unlock(&m->lock);
 
-		m->locked = false;
-		m->owner = -1;
-	spinlock_unlock(&m->lock);
+#if (__NANVIX_MUTEX_SLEEP)
+		/**
+		 * May be we need try to wakeup a thread more than one time because it
+		 * is not an atomic sleep/wakeup.
+		 *
+		 * Obs.: We release the primary lock because we don't need garantee
+		 * that the head thread gets the mutex.
+		 */
+		if (head != -1)
+			while (LIKELY(kwakeup(head) != 0));
 
-	return (0);
+	spinlock_unlock(&m->lock2);
+#endif
+
+	return (ret);
 }
 
 /*============================================================================*
@@ -296,7 +303,7 @@ int nanvix_mutex_destroy(struct nanvix_mutex *m)
 	KASSERT(m->owner == -1);
 	KASSERT(m->locked == false);
 	#if (__NANVIX_MUTEX_SLEEP)
-		KASSERT(m->tids[0] == -1);
+		KASSERT(m->size == 0);
 	#endif
 
 	m = NULL;

--- a/src/test/condvar.c
+++ b/src/test/condvar.c
@@ -146,6 +146,7 @@ static struct test condition_variables_tests_stress[] = {
 void test_condition_variables(void)
 {
 	/* API Tests */
+	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; condition_variables_tests_api[i].test_fn != NULL; i++)
 	{
 		condition_variables_tests_api[i].test_fn();

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -133,9 +133,9 @@ void ___start(int argc, const char *argv[])
 			test_thread_mgmt();
 			test_thread_sleep();
 		#if (CORES_NUM > 1)
-			test_condition_variables();
 			test_mutex();
 			test_semaphore();
+			test_condition_variables();
 		#endif
 
 		#ifndef __unix64__

--- a/src/test/mutex.c
+++ b/src/test/mutex.c
@@ -48,24 +48,31 @@ struct task_context
  * @param mutex Target mutex
  * @param i Number of iterations
  */
-static void test_mutex_recursive(struct nanvix_mutex *mutex, int i)
+PRIVATE void test_mutex_recursive(struct nanvix_mutex * mutex, int i)
 {
 	nanvix_mutex_lock(mutex);
-	test_assert(mutex->owner == kthread_self());
-	test_assert((int) mutex->locked == 1);
-	if (i != 0)
-		test_mutex_recursive(mutex, i - 1);
+
+		test_assert(mutex->owner == kthread_self());
+		test_assert((int) mutex->locked == 1);
+
+		if (i != 0)
+			test_mutex_recursive(mutex, i - 1);
+
 	nanvix_mutex_unlock(mutex);
 }
+
+/*============================================================================*
+ * Threads                                                                    *
+ *============================================================================*/
 
 /**
  * @brief Recursive task
  *
  * @param arg Target mutex
  */
-void *task_recursive(void *arg)
+PRIVATE void * task_recursive(void * arg)
 {
-	struct nanvix_mutex *mutex = (struct nanvix_mutex *) arg;
+	struct nanvix_mutex * mutex = (struct nanvix_mutex *) arg;
 
 	test_mutex_recursive(mutex, 10);
 
@@ -77,13 +84,13 @@ void *task_recursive(void *arg)
  *
  * @param arg Target mutex
  */
-void *task_lock_unlock(void *arg)
+PRIVATE void * task_lock_unlock(void * arg)
 {
-	struct nanvix_mutex *mutex = (struct nanvix_mutex *) arg;
+	struct nanvix_mutex * mutex = (struct nanvix_mutex *) arg;
 
 	nanvix_mutex_lock(mutex);
-	test_assert(mutex->owner == kthread_self());
-	test_assert((int) mutex->locked == 1);
+		test_assert(mutex->owner == kthread_self());
+		test_assert((int) mutex->locked == 1);
 	nanvix_mutex_unlock(mutex);
 
 	return (NULL);
@@ -96,9 +103,9 @@ void *task_lock_unlock(void *arg)
  *
  * @param arg Context for the task
  */
-void *task_mutex_function(void *arg)
+PRIVATE void * task_mutex_function(void * arg)
 {
-	struct task_context *ctx;
+	struct task_context * ctx;
 	ctx = (struct task_context *) arg;
 	int r;
 
@@ -118,14 +125,7 @@ void *task_mutex_function(void *arg)
 			r = 1;
 	}
 
-	if (ctx->success)
-	{
-		test_assert(r == 0);
-	}
-	else
-	{
-		test_assert(r < 0);
-	}
+	test_assert(ctx->success ? (r == 0) : (r < 0));
 
 	return (NULL);
 }
@@ -137,7 +137,7 @@ void *task_mutex_function(void *arg)
  * @param function Target mutex function
  * @param success Should the test work?
  */
-void test_mutex_function(struct nanvix_mutex *mutex, int function, int success)
+PRIVATE void test_mutex_function(struct nanvix_mutex * mutex, int function, int success)
 {
 	kthread_t tid;
 	struct task_context ctx = {mutex, function, success};
@@ -146,10 +146,18 @@ void test_mutex_function(struct nanvix_mutex *mutex, int function, int success)
 	test_assert(kthread_join(tid, NULL) == 0);
 }
 
+/*============================================================================*
+ * Mutex Unit Tests                                                           *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_api_mutex_normal()                                                    *
+ *----------------------------------------------------------------------------*/
+
 /**
  * @brief API test for normal mutex.
  */
-static void test_api_mutex_normal(void)
+PRIVATE void test_api_mutex_normal(void)
 {
 	struct nanvix_mutex mutex;
 
@@ -187,10 +195,14 @@ static void test_api_mutex_normal(void)
 	test_assert(nanvix_mutex_destroy(&mutex) == 0);
 }
 
+/*----------------------------------------------------------------------------*
+ * test_api_mutex_errorcheck()                                                *
+ *----------------------------------------------------------------------------*/
+
 /**
  * @brief API test for errorcheck mutex.
  */
-static void test_api_mutex_errorcheck(void)
+PRIVATE void test_api_mutex_errorcheck(void)
 {
 	struct nanvix_mutex mutex;
 	struct nanvix_mutexattr mattr;
@@ -237,10 +249,14 @@ static void test_api_mutex_errorcheck(void)
 	test_assert(nanvix_mutex_destroy(&mutex) == 0);
 }
 
+/*----------------------------------------------------------------------------*
+ * test_api_mutex_recursive()                                                 *
+ *----------------------------------------------------------------------------*/
+
 /**
  * @brief API test for recursive mutex.
  */
-static void test_api_mutex_recursive(void)
+PRIVATE void test_api_mutex_recursive(void)
 {
 	struct nanvix_mutex mutex;
 	struct nanvix_mutexattr mattr;
@@ -290,98 +306,177 @@ static void test_api_mutex_recursive(void)
 	test_assert(nanvix_mutex_destroy(&mutex) == 0);
 }
 
+/*============================================================================*
+ * Fault Unit Tests                                                           *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_fault_mutex_operations()                                              *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Fault test for normal mutex.
+ */
+PRIVATE void test_fault_mutex_operations(void)
+{
+	struct nanvix_mutexattr mattr;
+
+	test_assert(nanvix_mutex_init(NULL, NULL) < 0);
+	test_assert(nanvix_mutex_init(NULL, &mattr) < 0);
+	test_assert(nanvix_mutex_unlock(NULL) < 0);
+	test_assert(nanvix_mutex_unlock(NULL) < 0);
+	test_assert(nanvix_mutex_trylock(NULL) < 0);
+	test_assert(nanvix_mutex_destroy(NULL) < 0);
+}
+
+/*----------------------------------------------------------------------------*
+ * test_fault_mutexattr_operations()                                          *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Fault test for normal mutex.
+ */
+PRIVATE void test_fault_mutexattr_operations(void)
+{
+	struct nanvix_mutexattr mattr;
+
+	test_assert(nanvix_mutexattr_init(NULL) < 0);
+
+	test_assert(nanvix_mutexattr_settype(NULL, NANVIX_MUTEX_NORMAL) < 0);
+	test_assert(nanvix_mutexattr_settype(NULL, NANVIX_MUTEX_ERRORCHECK) < 0);
+	test_assert(nanvix_mutexattr_settype(NULL, NANVIX_MUTEX_ERRORCHECK) < 0);
+	test_assert(nanvix_mutexattr_settype(NULL, NANVIX_MUTEX_DEFAULT) < 0);
+
+	test_assert(nanvix_mutexattr_init(&mattr) == 0);
+		test_assert(nanvix_mutexattr_settype(&mattr, -1) < 0);
+		test_assert(nanvix_mutexattr_settype(&mattr, NANVIX_MUTEX_LIMIT) < 0);
+	test_assert(nanvix_mutexattr_destroy(&mattr) == 0);
+}
+
+/*============================================================================*
+ * Stress Unit Tests                                                          *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_stress_mutex_normal()                                                 *
+ *----------------------------------------------------------------------------*/
+
 /**
  * @brief Stress test for normal mutex
  */
-static void test_stress_mutex_normal(void)
+PRIVATE void test_stress_mutex_normal(void)
 {
-	#if (THREAD_MAX > 2)
-		struct nanvix_mutex mutex;
-		kthread_t tids[NTHREADS];
+#if (THREAD_MAX > 2)
+	struct nanvix_mutex mutex;
+	kthread_t tids[NTHREADS];
 
-		test_assert(nanvix_mutex_init(&mutex, NULL) == 0);
+	test_assert(nanvix_mutex_init(&mutex, NULL) == 0);
 
 		for (int i = 0; i < NTHREADS; i++)
-			kthread_create(&tids[i], task_lock_unlock, (void *) &mutex);
-		for (int i = 0; i < NTHREADS; i++)
-			kthread_join(tids[i], NULL);
+			test_assert(kthread_create(&tids[i], task_lock_unlock, (void *) &mutex) == 0);
 
-		test_assert(nanvix_mutex_destroy(&mutex) == 0);
-	#endif
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+	test_assert(nanvix_mutex_destroy(&mutex) == 0);
+#endif
 }
+
+/*----------------------------------------------------------------------------*
+ * test_stress_mutex_errorcheck()                                             *
+ *----------------------------------------------------------------------------*/
 
 /**
  * @brief Stress test for errorcheck mutex
  */
-static void test_stress_mutex_errorcheck(void)
+PRIVATE void test_stress_mutex_errorcheck(void)
 {
-	#if (THREAD_MAX > 2)
-		struct nanvix_mutex mutex;
-		struct nanvix_mutexattr mattr;
-		kthread_t tids[NTHREADS];
+#if (THREAD_MAX > 2)
+	struct nanvix_mutex mutex;
+	struct nanvix_mutexattr mattr;
+	kthread_t tids[NTHREADS];
 
-		test_assert(nanvix_mutexattr_init(&mattr) == 0);
-		test_assert(nanvix_mutexattr_settype(&mattr, NANVIX_MUTEX_ERRORCHECK) == 0);
-		test_assert(nanvix_mutex_init(&mutex, &mattr) == 0);
+	test_assert(nanvix_mutexattr_init(&mattr) == 0);
+	test_assert(nanvix_mutexattr_settype(&mattr, NANVIX_MUTEX_ERRORCHECK) == 0);
+	test_assert(nanvix_mutex_init(&mutex, &mattr) == 0);
 
 		for (int i = 0; i < NTHREADS; i++)
-			kthread_create(&tids[i], task_lock_unlock, (void *) &mutex);
-		for (int i = 0; i < NTHREADS; i++)
-			kthread_join(tids[i], NULL);
+			test_assert(kthread_create(&tids[i], task_lock_unlock, (void *) &mutex) == 0);
 
-		test_assert(nanvix_mutexattr_destroy(&mattr) == 0);
-		test_assert(nanvix_mutex_destroy(&mutex) == 0);
-	#endif
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+	test_assert(nanvix_mutexattr_destroy(&mattr) == 0);
+	test_assert(nanvix_mutex_destroy(&mutex) == 0);
+#endif
 }
+
+/*----------------------------------------------------------------------------*
+ * test_stress_mutex_recursive()                                              *
+ *----------------------------------------------------------------------------*/
 
 /**
  * @brief Stress test for recursive mutex
  */
-static void test_stress_mutex_recursive(void)
+PRIVATE void test_stress_mutex_recursive(void)
 {
-	#if (THREAD_MAX > 2)
-		struct nanvix_mutex mutex;
-		struct nanvix_mutexattr mattr;
-		kthread_t tids[NTHREADS];
+#if (THREAD_MAX > 2)
+	struct nanvix_mutex mutex;
+	struct nanvix_mutexattr mattr;
+	kthread_t tids[NTHREADS];
 
-		test_assert(nanvix_mutexattr_init(&mattr) == 0);
-		test_assert(nanvix_mutexattr_settype(&mattr, NANVIX_MUTEX_RECURSIVE) == 0);
-		test_assert(nanvix_mutex_init(&mutex, &mattr) == 0);
+	test_assert(nanvix_mutexattr_init(&mattr) == 0);
+	test_assert(nanvix_mutexattr_settype(&mattr, NANVIX_MUTEX_RECURSIVE) == 0);
+	test_assert(nanvix_mutex_init(&mutex, &mattr) == 0);
 
 		for (int i = 0; i < NTHREADS; i++)
-			kthread_create(&tids[i], task_recursive, (void *) &mutex);
-		for (int i = 0; i < NTHREADS; i++)
-			kthread_join(tids[i], NULL);
+			test_assert(kthread_create(&tids[i], task_recursive, (void *) &mutex) == 0);
 
-		test_assert(nanvix_mutexattr_destroy(&mattr) == 0);
-		test_assert(nanvix_mutex_destroy(&mutex) == 0);
-	#endif
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+	test_assert(nanvix_mutexattr_destroy(&mattr) == 0);
+	test_assert(nanvix_mutex_destroy(&mutex) == 0);
+#endif
 }
+
+/*============================================================================*
+ * Test Driver                                                                *
+ *============================================================================*/
 
 /**
  * @brief API tests.
  */
-static struct test mutex_tests_api[] = {
+PRIVATE struct test mutex_tests_api[] = {
 	{ test_api_mutex_normal,     "[test][mutex][api] mutex normal     [passed]" },
 	{ test_api_mutex_errorcheck, "[test][mutex][api] mutex errorcheck [passed]" },
 	{ test_api_mutex_recursive,  "[test][mutex][api] mutex recursive  [passed]" },
-	{ NULL,                      NULL                                           },
+	{ NULL,                       NULL                                          },
+};
+
+/**
+ * @brief Fault tests.
+ */
+PRIVATE struct test mutex_tests_fault[] = {
+	{ test_fault_mutex_operations,     "[test][mutex][fault] mutex operations     [passed]" },
+	{ test_fault_mutexattr_operations, "[test][mutex][fault] mutexattr operations [passed]" },
+	{ NULL,                             NULL                                                },
 };
 
 /**
  * @brief Stress tests.
  */
-static struct test mutex_tests_stress[] = {
+PRIVATE struct test mutex_tests_stress[] = {
 	{ test_stress_mutex_normal,     "[test][mutex][stress] mutex normal     [passed]" },
 	{ test_stress_mutex_errorcheck, "[test][mutex][stress] mutex errorcheck [passed]" },
 	{ test_stress_mutex_recursive,  "[test][mutex][stress] mutex recursive  [passed]" },
-	{ NULL,                      NULL                                           },
+	{ NULL,                          NULL                                             },
 };
 
 /**
  * @brief Mutex test laucher.
  */
-void test_mutex(void)
+PUBLIC void test_mutex(void)
 {
 	/* API Tests */
 	nanvix_puts("--------------------------------------------------------------------------------");
@@ -390,7 +485,16 @@ void test_mutex(void)
 		mutex_tests_api[i].test_fn();
 		nanvix_puts(mutex_tests_api[i].name);
 	}
-	/* stress tests */
+
+	/* Fault Tests */
+	nanvix_puts("--------------------------------------------------------------------------------");
+	for (int i = 0; mutex_tests_fault[i].test_fn != NULL; i++)
+	{
+		mutex_tests_fault[i].test_fn();
+		nanvix_puts(mutex_tests_fault[i].name);
+	}
+
+	/* Stress tests */
 	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; mutex_tests_stress[i].test_fn != NULL; i++)
 	{
@@ -400,3 +504,4 @@ void test_mutex(void)
 }
 
 #endif  /* CORES_NUM */
+

--- a/src/test/semaphore.c
+++ b/src/test/semaphore.c
@@ -26,65 +26,469 @@
 #include <nanvix/sys/semaphore.h>
 #include "test.h"
 
+#if (CORES_NUM > 1)
+
+/**
+ * @brief Number of iterations.
+ */
+#define CITERATIONS (50000 / NTHREADS)
+
+/**
+ * @name Benchmark Parameters
+ */
+/**@{*/
+#define OBJSIZE                        (128) /**< Maximum Object Size                    */
+#define BUFLEN                           16  /**< Buffer Length                          */
+#define NOBJECTS                         32  /**< Number of Objects                      */
+#define WORD_OBJSIZE   (OBJSIZE / WORD_SIZE) /**< Size of a object in words              */
+#define BUFFER_SIZE  (BUFLEN * WORD_OBJSIZE) /**< Buffer data size from objects          */
+/**@}*/
+
+/**
+ * @brief Semaphores used in tests
+ */
+PRIVATE struct nanvix_semaphore sem;
+
+#if (THREAD_MAX > 2)
 
 /**
  * @brief Global variable used in semaphore tests
  */
-int counter;
+PRIVATE int counter;
 
 /**
- * @brief Semaphore used in tests
+ * @brief Buffer.
  */
-struct nanvix_semaphore sem;
-
-/**
- * @brief Trywait test task
- */
-void *task(void *arg)
+struct buffer
 {
-	int iterations = *(int *)arg;
-	for (int i = 0; i < iterations; i++)
+	size_t first;
+	size_t last;
+	struct nanvix_semaphore lock;
+	struct nanvix_semaphore full;
+	struct nanvix_semaphore empty;
+	word_t data[BUFFER_SIZE];
+};
+
+/**
+ * @brief Task info.
+ */
+struct tdata
+{
+	int n;
+	int tnum;
+	bool verify;
+	struct buffer * buf;
+	word_t data[WORD_OBJSIZE];
+} tdata[NTHREADS] ALIGN(CACHE_LINE_SIZE);
+
+/**
+ * @brief Buffers.
+ */
+PRIVATE struct buffer buffers[NTHREADS / 2];
+
+/*============================================================================*
+ * Threads                                                                    *
+ *============================================================================*/
+
+/**
+ * @brief Down test.
+ */
+PRIVATE void * counter_down_task(void * arg)
+{
+	UNUSED(arg);
+
+	for (int i = 0; i < CITERATIONS; i++)
+	{
+		test_assert(nanvix_semaphore_down(&sem) == 0);
+			counter++;
+		test_assert(nanvix_semaphore_up(&sem) == 0);
+	}
+
+	return NULL;
+}
+
+/**
+ * @brief Trywait test.
+ */
+PRIVATE void *counter_trywait_task(void * arg)
+{
+	UNUSED(arg);
+
+	for (int i = 0; i < CITERATIONS; i++)
 	{
 		while (nanvix_semaphore_trywait(&sem) != 0);
 		counter++;
 		nanvix_semaphore_up(&sem);
 	}
+
 	return NULL;
 }
 
-/*
- * @brief Stress test for trywait
+/**
+ * @brief Initializes a buffer.
  */
-static void test_stress_trywait(void)
+PRIVATE void buffer_init(struct buffer * buf, int nslots)
 {
-	#if (THREAD_MAX > 2)
-		int iterations = 5000000/NTHREADS;
-		kthread_t tids[NTHREADS];
-		nanvix_semaphore_init(&sem, 1);
-
-		for (int i = 0; i < NTHREADS; i++)
-			kthread_create(&tids[i], task, (void *) &iterations);
-
-		for (int i = 0; i < NTHREADS; i++)
-			kthread_join(tids[i], NULL);
-
-		test_assert(counter == NTHREADS * iterations);
-	#endif
+	buf->first = 0;
+	buf->last  = 0;
+	nanvix_semaphore_init(&buf->lock, 1);
+	nanvix_semaphore_init(&buf->full, 0);
+	nanvix_semaphore_init(&buf->empty, nslots - 1);
 }
+
+/**
+ * @brief Initializes a buffer.
+ */
+PRIVATE void buffer_destroy(struct buffer * buf)
+{
+	nanvix_semaphore_destroy(&buf->lock);
+	nanvix_semaphore_destroy(&buf->full);
+	nanvix_semaphore_destroy(&buf->empty);
+}
+
+/**
+ * @brief Puts an object in a buffer.
+ *
+ * @param buf  Target buffer.
+ * @param data Data to place in the buffer.
+ */
+PRIVATE inline void buffer_put(struct buffer * buf, const word_t * data)
+{
+	kmemcpy(&buf->data[buf->first], data, OBJSIZE);
+	buf->first = (buf->first + WORD_OBJSIZE) % BUFFER_SIZE;
+}
+
+/**
+ * @brief Gets an object from a buffer.
+ *
+ * @param buf  Target buffer.
+ * @param data Location to store the data.
+ */
+PRIVATE inline void buffer_get(struct buffer *buf, word_t *data)
+{
+	kmemcpy(data, &buf->data[buf->last], OBJSIZE);
+	buf->last = (buf->last + WORD_OBJSIZE) % BUFFER_SIZE;
+}
+
+/**
+ * @brief Producer.
+ */
+PRIVATE void * producer(void * arg)
+{
+	struct tdata * t    = arg;
+	struct buffer * buf = t->buf;
+
+	do
+	{
+		for (size_t i = 0; i < WORD_OBJSIZE; ++i)
+			t->data[i] = (word_t) (t->verify ? t->n : -1);
+
+		nanvix_semaphore_down(&buf->empty);
+			nanvix_semaphore_down(&buf->lock);
+
+				buffer_put(buf, t->data);
+
+			nanvix_semaphore_up(&buf->lock);
+		nanvix_semaphore_up(&buf->full);
+
+	} while (--t->n > 0);
+
+	return NULL;
+}
+
+/**
+ * @brief Consumer.
+ */
+PRIVATE void * consumer(void * arg)
+{
+	struct tdata * t    = arg;
+	struct buffer * buf = t->buf;
+
+	do
+	{
+		for (size_t i = 0; i < WORD_OBJSIZE; ++i)
+			t->data[i] = (word_t) -1;
+
+		nanvix_semaphore_down(&buf->full);
+			nanvix_semaphore_down(&buf->lock);
+
+				buffer_get(buf, t->data);
+
+			nanvix_semaphore_up(&buf->lock);
+		nanvix_semaphore_up(&buf->empty);
+
+		for (size_t i = 0; i < WORD_OBJSIZE; ++i)
+			test_assert(t->data[i] == (word_t) (t->verify ? t->n : -1));
+
+	} while (--t->n > 0);
+
+	return NULL;
+}
+
+#endif /* THREADS_MAX > 2 */
+
+/*============================================================================*
+ * Semaphore Unit Tests                                                       *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_api_semaphore_init()                                                  *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief API Init and destroy  a semaphore.
+ */
+PRIVATE void test_api_semaphore_init(void)
+{
+	test_assert(nanvix_semaphore_init(&sem, 1) == 0);
+	test_assert(nanvix_semaphore_destroy(&sem) == 0);
+}
+
+/*----------------------------------------------------------------------------*
+ * test_api_semaphore_up_down()                                               *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief API Init and destroy  a semaphore.
+ */
+PRIVATE void test_api_semaphore_up_down(void)
+{
+	test_assert(nanvix_semaphore_init(&sem, 1) == 0);
+
+		/* Normal. */
+		test_assert(nanvix_semaphore_down(&sem) == 0);
+		test_assert(nanvix_semaphore_up(&sem) == 0);
+
+		/* Try wait. */
+		test_assert(nanvix_semaphore_trywait(&sem) == 0);
+		test_assert(nanvix_semaphore_trywait(&sem) < 0);
+
+		/* Conter. */
+		test_assert(nanvix_semaphore_up(&sem) == 0);
+		test_assert(nanvix_semaphore_up(&sem) == 0);
+			test_assert(nanvix_semaphore_down(&sem) == 0);
+			test_assert(nanvix_semaphore_up(&sem) == 0);
+		test_assert(nanvix_semaphore_down(&sem) == 0);
+		test_assert(nanvix_semaphore_down(&sem) == 0);
+		test_assert(nanvix_semaphore_trywait(&sem) < 0);
+
+	test_assert(nanvix_semaphore_destroy(&sem) == 0);
+}
+
+/*----------------------------------------------------------------------------*
+ * test_api_semaphore_producer_consumer()                                     *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief API Init and destroy  a semaphore.
+ */
+PRIVATE void test_api_semaphore_producer_consumer(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[2];
+
+	struct buffer * buf;
+
+	buffer_init(buf = &buffers[0], BUFLEN);
+
+	tdata[0].tnum   = 0;
+	tdata[1].tnum   = 1;
+	tdata[0].n      = tdata[1].n      = NOBJECTS;
+	tdata[0].buf    = tdata[1].buf    = buf;
+	tdata[0].verify = tdata[1].verify = true;
+
+	test_assert(kthread_create(&tids[0], producer, &tdata[0]) == 0);
+	test_assert(kthread_create(&tids[1], consumer, &tdata[1]) == 0);
+
+	test_assert(kthread_join(tids[0], NULL) == 0);
+	test_assert(kthread_join(tids[1], NULL) == 0);
+
+	buffer_destroy(buf);
+#endif
+}
+
+/*============================================================================*
+ * Semaphore Fault Tests                                                      *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_fault_semaphore_init()                                                *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Fault test for init and destroy.
+ */
+PRIVATE void test_fault_semaphore_init(void)
+{
+	test_assert(nanvix_semaphore_init(NULL, 1) < 0);
+	test_assert(nanvix_semaphore_init(&sem, -1) < 0);
+	test_assert(nanvix_semaphore_destroy(NULL) < 0);
+}
+
+/*----------------------------------------------------------------------------*
+ * test_fault_semaphore_up_down()                                             *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Fault test for up/down/trywait.
+ */
+PRIVATE void test_fault_semaphore_up_down(void)
+{
+	test_assert(nanvix_semaphore_up(NULL) < 0);
+	test_assert(nanvix_semaphore_down(NULL) < 0);
+	test_assert(nanvix_semaphore_trywait(NULL) < 0);
+}
+
+/*============================================================================*
+ * Semaphore Stress Tests                                                     *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_stress_semaphore_up_down()                                            *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Stress test for up/down.
+ */
+PRIVATE void test_stress_semaphore_up_down(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[NTHREADS];
+
+	counter = 0;
+	test_assert(nanvix_semaphore_init(&sem, 1) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_create(&tids[i], counter_down_task, NULL) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+		test_assert(counter == NTHREADS * CITERATIONS);
+
+	test_assert(nanvix_semaphore_destroy(&sem) == 0);
+#endif
+}
+
+/*----------------------------------------------------------------------------*
+ * test_stress_semaphore_trywait()                                            *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Stress test for trywait.
+ */
+PRIVATE void test_stress_semaphore_trywait(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[NTHREADS];
+
+	counter = 0;
+	test_assert(nanvix_semaphore_init(&sem, 1) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_create(&tids[i], counter_trywait_task, NULL) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+		test_assert(counter == NTHREADS * CITERATIONS);
+
+	test_assert(nanvix_semaphore_destroy(&sem) == 0);
+#endif
+}
+
+/*----------------------------------------------------------------------------*
+ * test_stress_semaphore_producer_consumer()                                  *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Stress test for producer/consumer.
+ */
+PRIVATE void test_stress_semaphore_producer_consumer(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[NTHREADS];
+
+	for (int i = 0; (i + 1) < NTHREADS; i += 2)
+	{
+		struct buffer * buf;
+
+		buffer_init(buf = &buffers[i / 2], BUFLEN);
+
+		tdata[i].tnum     = i;
+		tdata[i + 1].tnum = i + 1;
+		tdata[i].n      = tdata[i + 1].n      = NOBJECTS;
+		tdata[i].buf    = tdata[i + 1].buf    = buf;
+		tdata[i].verify = tdata[i + 1].verify = false;
+
+		test_assert(kthread_create(&tids[i], producer, &tdata[i]) == 0);
+		test_assert(kthread_create(&tids[i + 1], consumer, &tdata[i + 1]) == 0);
+	}
+
+	for (int i = 0; (i + 1) < NTHREADS; i += 2)
+	{
+		test_assert(kthread_join(tids[i], NULL) == 0);
+		test_assert(kthread_join(tids[i + 1], NULL) == 0);
+
+		buffer_destroy(&buffers[i / 2]);
+	}
+#endif
+}
+
+/*============================================================================*
+ * Test Driver                                                                *
+ *============================================================================*/
 
 /**
  * @brief Stress tests.
  */
-static struct test test_stress_semaphore[] = {
-	{ test_stress_trywait, "[test][semaphore][stress] trywait [passed]" },
-	{ NULL,                NULL                                         },
+PRIVATE struct test test_api_semaphore[] = {
+	{ test_api_semaphore_init,              "[test][semaphore][api] Init/Destroy      [passed]" },
+	{ test_api_semaphore_up_down,           "[test][semaphore][api] Up/Down           [passed]" },
+	{ test_api_semaphore_producer_consumer, "[test][semaphore][api] Producer-Consumer [passed]" },
+	{ NULL,                                  NULL                                               },
+};
+
+/**
+ * @brief Fault tests.
+ */
+PRIVATE struct test test_fault_semaphore[] = {
+	{ test_fault_semaphore_init,              "[test][semaphore][fault] Init/Destroy    [passed]" },
+	{ test_fault_semaphore_up_down,           "[test][semaphore][fault] Up/Down/Trywait [passed]" },
+	{ NULL,                                    NULL                                               },
+};
+
+/**
+ * @brief Stress tests.
+ */
+PRIVATE struct test test_stress_semaphore[] = {
+	{ test_stress_semaphore_up_down,           "[test][semaphore][stress] Up/Down [passed]"           },
+	{ test_stress_semaphore_trywait,           "[test][semaphore][stress] Trywait [passed]"           },
+	{ test_stress_semaphore_producer_consumer, "[test][semaphore][stress] Producer-Consumer [passed]" },
+	{ NULL,                                     NULL                                                  },
 };
 
 /**
  * @brief Semaphore test launcher
  */
-void test_semaphore(void)
+PUBLIC void test_semaphore(void)
 {
+	/* API Tests */
+	nanvix_puts("--------------------------------------------------------------------------------");
+	for (int i = 0; test_api_semaphore[i].test_fn != NULL; i++)
+	{
+		test_api_semaphore[i].test_fn();
+		nanvix_puts(test_api_semaphore[i].name);
+	}
+
+	/* Fault Tests */
+	nanvix_puts("--------------------------------------------------------------------------------");
+	for (int i = 0; test_fault_semaphore[i].test_fn != NULL; i++)
+	{
+		test_fault_semaphore[i].test_fn();
+		nanvix_puts(test_fault_semaphore[i].name);
+	}
+
 	/* Stress Tests */
 	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; test_stress_semaphore[i].test_fn != NULL; i++)
@@ -93,3 +497,6 @@ void test_semaphore(void)
 		nanvix_puts(test_stress_semaphore[i].name);
 	}
 }
+
+#endif /* CORES_NUM > 1 */
+


### PR DESCRIPTION
In this PR, I change the responsibility of how the mutex/semaphore/condvar deals with the sleep/wakeup calls.
This change is needed because the previous one can introduce deadlocks/livelocks on incoming submodules changes.