### PR TITLE
[pm][ikc] Feature: preemptive threads

### DIFF
--- a/include/nanvix/runtime/fence.h
+++ b/include/nanvix/runtime/fence.h
@@ -25,29 +25,43 @@
 #ifndef NANVIX_RUNTIME_FENCE_H_
 #define NANVIX_RUNTIME_FENCE_H_
 
+	#include <nanvix/sys/condvar.h>
 	#include <nanvix/sys/mutex.h>
 
+#if (CORES_NUM > 1)
+
 	/**
-	 * @brief Fence
+	 * @brief Fence.
 	 */
-	struct fence_t
+	struct nanvix_fence
 	{
-		int ncores;      /**< Number of cores in the fence.           */
-		int nreached;    /**< Number of cores that reached the fence. */
-		int release;     /**< Wait condition.                         */
-		spinlock_t lock; /**< Lock.                                   */
+		int release;                 /**< Wait condition.                           */
+		int nthreads;                /**< Number of threads in the fence.           */
+		int nreached;                /**< Number of threads that reached the fence. */
+		struct nanvix_mutex mutex;   /**< Mutex.                                    */
+		struct nanvix_cond_var cond; /**< Condition.                                */
 	};
 
 	/**
 	 * @brief Initializes a fence.
 	 *
-	 * @param b      Target fence.
- 	 * @param ncores Number of cores in the fence.
+	 * @param b        Target fence.
+	 * @param nthreads Number of threads in the fence.
 	 *
 	 * @returns Upons sucessful completion zero is returned. Upon failure,
 	 * a negative number is returned instead.
 	 */
-	extern void fence_init(struct fence_t *b, int ncores);
+	extern int nanvix_fence_init(struct nanvix_fence * b, int nthreads);
+
+	/**
+	 * @brief Destroy a fence.
+	 *
+	 * @param b Target fence.
+	 *
+	 * @returns Upons sucessful completion zero is returned. Upon failure,
+	 * a negative number is returned instead.
+	 */
+	extern int nanvix_fence_destroy(struct nanvix_fence * b);
 
 	/**
 	 * @brief Waits in a fence until the defined number of threads reach it.
@@ -57,6 +71,9 @@
 	 * @returns Upon sucessful completion, zero is returned. Upon failure a
 	 * negative errorcode is returned instead.
 	 */
-	extern void fence(struct fence_t *b);
+	extern int nanvix_fence(struct nanvix_fence * b);
+
+#endif /* CORES_NUM > 1 */
 
 #endif /* NANVIX_RUNTIME_FENCE_H_ */
+

--- a/include/nanvix/runtime/stdikc.h
+++ b/include/nanvix/runtime/stdikc.h
@@ -29,6 +29,7 @@
 	#include <nanvix/sys/noc.h>
 	#include <nanvix/sys/portal.h>
 	#include <nanvix/sys/sync.h>
+	#include <nanvix/sys/thread.h>
 
 /*============================================================================*
  * Kernel Standard Synchronization Point                                      *
@@ -80,6 +81,15 @@
 	extern int stdinbox_get(void);
 
 	/**
+	 * @brief Gets the kernel standard input mailbox.
+	 *
+	 * @arg tid Thread ID.
+	 *
+	 * @return The kernel standard input mailbox.
+	 */
+	extern int stdinbox_get_specific(kthread_t tid);
+
+	/**
 	 * @brief Initializes the kernel standard mailbox facility.
 	 *
 	 * @return Upon successful completion, a non-negative number is
@@ -115,6 +125,15 @@
 	 * @return The kernel standard input portal.
 	 */
 	extern int stdinportal_get(void);
+
+	/**
+	 * @brief Gets the kernel standard input portal.
+	 *
+	 * @arg tid Thread ID.
+	 *
+	 * @return The kernel standard input portal.
+	 */
+	extern int stdinportal_get_specific(kthread_t tid);
 
 	/**
 	 * @brief Initializes the kernel standard portal facility.

--- a/include/nanvix/sys/condvar.h
+++ b/include/nanvix/sys/condvar.h
@@ -43,7 +43,6 @@
 	struct nanvix_cond_var
 	{
 		spinlock_t lock;
-		spinlock_t lock2;
 
 		int begin;                  /**< Fist valid element.    */
 		int end;                    /**< Last valid element.    */

--- a/include/nanvix/sys/mutex.h
+++ b/include/nanvix/sys/mutex.h
@@ -69,8 +69,6 @@
 			int size;                   /**< Current queue size.    */
 			kthread_t tids[THREAD_MAX]; /**< Buffer.                */
 
-			spinlock_t lock2;           /**< Exclusive unlock call. */
-
 		#endif /* __NANVIX_MUTEX_SLEEP */
 	};
 

--- a/include/nanvix/sys/semaphore.h
+++ b/include/nanvix/sys/semaphore.h
@@ -51,8 +51,6 @@
 			int size;                   /**< Current queue size.    */
 			kthread_t tids[THREAD_MAX]; /**< Buffer.                */
 
-			spinlock_t lock2;           /**< Exclusive unlock call. */
-
 		#endif /* __NANVIX_SEMAPHORE_SLEEP */
 	};
 
@@ -94,7 +92,7 @@
 	 * @return Upon sucessful completion, zero is returned. Upon failure, a
 	 * negative error code is returned instead.
 	 */
-	extern int nanvix_semaphore_trywait(struct nanvix_semaphore *sem);
+	extern int nanvix_semaphore_trydown(struct nanvix_semaphore *sem);
 
 	/**
 	 * @brief Destroy a semaphore

--- a/include/nanvix/sys/thread.h
+++ b/include/nanvix/sys/thread.h
@@ -46,6 +46,8 @@
 	extern int kthread_exit(void *);
 	extern int kthread_join(kthread_t, void **);
 	extern int kthread_yield(void);
+	extern int kthread_set_affinity(int);
+	extern int kthread_stats(kthread_t, uint64_t *, int);
 	/**@}*/
 
 	/**

--- a/src/libnanvix/ikc/stdsync.c
+++ b/src/libnanvix/ikc/stdsync.c
@@ -84,7 +84,7 @@ int __stdsync_setup(void)
 	int tid;
 	int nodes[PROCESSOR_CLUSTERS_NUM];
 
-	if ((tid = kthread_self()) > THREAD_MAX)
+	if ((tid = kthread_self()) > KTHREAD_MAX)
 		return (-1);
 
 	build_node_list(nodes, PROCESSOR_IOCLUSTERS_NUM, PROCESSOR_CCLUSTERS_NUM);
@@ -104,7 +104,7 @@ int __stdsync_cleanup(void)
 	int tid;
 	int ret;
 
-	if ((tid = kthread_self()) > THREAD_MAX)
+	if ((tid = kthread_self()) > KTHREAD_MAX)
 		return (-1);
 
 	ret = barrier_destroy(__stdbarrier[tid]);
@@ -121,7 +121,7 @@ int stdsync_fence(void)
 	int tid;
 	int ret;
 
-	if ((tid = kthread_self()) > THREAD_MAX)
+	if ((tid = kthread_self()) > KTHREAD_MAX)
 		return (-1);
 
 	ret = barrier_wait(__stdbarrier[tid]);

--- a/src/libnanvix/thread/mutex.c
+++ b/src/libnanvix/thread/mutex.c
@@ -65,8 +65,6 @@ PUBLIC int nanvix_mutex_init(struct nanvix_mutex * m, struct nanvix_mutexattr * 
 		for (int i = 0; i < THREAD_MAX; i++)
 			m->tids[i] = -1;
 
-		spinlock_init(&m->lock2);
-
 	#endif /* __NANVIX_MUTEX_SLEEP */
 
 	dcache_invalidate();
@@ -220,7 +218,6 @@ PUBLIC int nanvix_mutex_unlock(struct nanvix_mutex * m)
 
 #if (__NANVIX_MUTEX_SLEEP)
 	int head = -1;
-	spinlock_lock(&m->lock2);
 #endif
 
 		spinlock_lock(&m->lock);
@@ -277,8 +274,6 @@ exit:
 		 */
 		if (head != -1)
 			while (LIKELY(kwakeup(head) != 0));
-
-	spinlock_unlock(&m->lock2);
 #endif
 
 	return (ret);

--- a/src/libnanvix/thread/thread.c
+++ b/src/libnanvix/thread/thread.c
@@ -149,6 +149,70 @@ int kthread_yield(void)
 	return (ret);
 }
 
+/*============================================================================*
+ * kthread_set_affinity()                                                     *
+ *============================================================================*/
+
+/*
+ * @see kernel_thread_set_affinity()
+ */
+int kthread_set_affinity(int new_affinity)
+{
+	int ret;
+
+	/* Invalid affinity. */
+	if (!KTHREAD_AFFINITY_IS_VALID(new_affinity))
+	{
+		errno = EINVAL;
+		return (-1);
+	}
+
+	ret = kcall1(
+		NR_thread_set_affinity,
+		(word_t) new_affinity
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kthread_stats()                                                            *
+ *============================================================================*/
+
+/*
+ * @see sys_kthread_stats()
+ */
+int kthread_stats(
+	kthread_t tid,
+	uint64_t * buffer,
+	int stat
+)
+{
+	int ret;
+
+	ret = kcall3(
+		NR_thread_stats,
+		(word_t) tid,
+		(word_t) buffer,
+		(word_t) stat
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
+}
 
 /*============================================================================*
  * ksleep()                                                                   *

--- a/src/test/barrier.c
+++ b/src/test/barrier.c
@@ -75,11 +75,11 @@ PUBLIC void test_barrier_nodes_setup(const int * nodes, int nnodes, int is_maste
 	{
 		_syncin  = ksync_create(nodes, nnodes, SYNC_ALL_TO_ONE);
 		_syncout = ksync_open(nodes, nnodes, SYNC_ONE_TO_ALL);
+
+		test_delay(1, CLUSTER_FREQ);
 	}
 	else
 	{
-		test_delay(1, CLUSTER_FREQ);
-
 		_syncout = ksync_open(nodes, nnodes, SYNC_ALL_TO_ONE);
 		_syncin  = ksync_create(nodes, nnodes, SYNC_ONE_TO_ALL);
 	}
@@ -94,13 +94,13 @@ PUBLIC void test_barrier_nodes(void)
 {
 	if (_node_is_master)
 	{
-		ksync_wait(_syncin);
 		ksync_signal(_syncout);
+		ksync_wait(_syncin);
 	}
 	else
 	{
-		ksync_signal(_syncout);
 		ksync_wait(_syncin);
+		ksync_signal(_syncout);
 	}
 }
 

--- a/src/test/condvar.c
+++ b/src/test/condvar.c
@@ -325,11 +325,15 @@ PRIVATE struct test condition_variables_tests_stress[] = {
 	{ NULL,                           NULL                                                                   },
 };
 
+#endif  /* CORES_NUM */
+
 /**
  * @brief Condition variable tests laucher
  */
 PUBLIC void test_condition_variables(void)
 {
+#if (CORES_NUM > 1)
+
 	/* API Tests */
 	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; condition_variables_tests_api[i].test_fn != NULL; i++)
@@ -353,7 +357,7 @@ PUBLIC void test_condition_variables(void)
 		condition_variables_tests_stress[i].test_fn();
 		nanvix_puts(condition_variables_tests_stress[i].name);
 	}
-}
 
 #endif  /* CORES_NUM */
+}
 

--- a/src/test/fence.c
+++ b/src/test/fence.c
@@ -1,0 +1,350 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ #include <nanvix/sys/thread.h>
+ #include <nanvix/runtime/fence.h>
+ #include "test.h"
+
+#if (CORES_NUM > 1)
+
+/*
+ * @brief Number of synchronizations.
+ */
+#define NSYNCS 50
+
+/*
+ * @brief Fence variable used in tests.
+ */
+PRIVATE struct nanvix_fence fence;
+
+/*
+ * @brief Auxiliar spinlock.
+ */
+PRIVATE spinlock_t flock;
+
+/*
+ * @brief Auxiliar of synchronizations.
+ */
+PRIVATE int nsyncs;
+
+/*============================================================================*
+ * Threads                                                                    *
+ *============================================================================*/
+
+/*
+ * @brief Fence auxiliar. Verify if the nsyncs is inside the range
+ * [ time * nthreads, (time + 1) * nthreads ).
+ */
+PRIVATE bool verify_fence_syncs(int time, int nthreads)
+{
+	return (WITHIN(nsyncs, time * nthreads, (time + 1) * nthreads));
+}
+
+/*
+ * @brief Task called in fence variable tests.
+ */
+PRIVATE void * fence_sanity(void * arg)
+{
+	UNUSED(arg);
+
+	spinlock_lock(&flock);
+		test_assert(verify_fence_syncs(0, fence.nthreads));
+		nsyncs++;
+	spinlock_unlock(&flock);
+
+	test_assert(nanvix_fence(&fence) == 0);
+
+	spinlock_lock(&flock);
+		test_assert(verify_fence_syncs(1, fence.nthreads));
+		nsyncs++;
+	spinlock_unlock(&flock);
+
+	test_assert(nanvix_fence(&fence) == 0);
+
+	spinlock_lock(&flock);
+		test_assert(verify_fence_syncs(2, fence.nthreads));
+		nsyncs++;
+	spinlock_unlock(&flock);
+
+	test_assert(nanvix_fence(&fence) == 0);
+
+	spinlock_lock(&flock);
+		test_assert(nsyncs == (3 * fence.nthreads));
+	spinlock_unlock(&flock);
+
+	return (NULL);
+}
+
+/*
+ * @brief Task called in fence variable tests.
+ */
+PRIVATE void * fence_do(void * arg)
+{
+	UNUSED(arg);
+
+	/* Do N synchronizations. */
+	for (int i = 0; i < nsyncs; ++i)
+		test_assert(nanvix_fence(&fence) == 0);
+
+	return (NULL);
+}
+
+/*============================================================================*
+ * fence Unit Tests                                                         *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_api_fence_init()                                                    *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Test for condition variable
+ *
+ * Tests condition variable initialization
+ */
+PRIVATE void test_api_fence_init(void)
+{
+	test_assert(nanvix_fence_init(&fence, 1) == 0);
+
+		test_assert(nanvix_fence(&fence) == 0);
+
+	test_assert(nanvix_fence_destroy(&fence) == 0);
+}
+
+/*----------------------------------------------------------------------------*
+ * test_api_fence_sanity()                                                    *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Test sanity for fence variable.
+ *
+ * Tests fence variable behavior using two threads
+ */
+PRIVATE void test_api_fence_sanity(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[2];
+
+	nsyncs = 0;
+
+	test_assert(nanvix_fence_init(&fence, 2) == 0);
+
+		for (int i = 0; i < 2; i++)
+			test_assert(kthread_create(&tids[i], fence_sanity, NULL) == 0);
+
+		for (int i = 0; i < 2; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+	test_assert(nanvix_fence_destroy(&fence) == 0);
+#endif
+}
+
+/*----------------------------------------------------------------------------*
+ * test_api_fence_do()                                                        *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Test broadcast for condition variable.
+ *
+ * Tests condition variable behavior using two threads
+ */
+PRIVATE void test_api_fence_do(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[2];
+
+	nsyncs = NSYNCS;
+
+	test_assert(nanvix_fence_init(&fence, 2) == 0);
+
+		for (int i = 0; i < 2; i++)
+			test_assert(kthread_create(&tids[i], fence_do, NULL) == 0);
+
+		for (int i = 0; i < 2; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+	test_assert(nanvix_fence_destroy(&fence) == 0);
+#endif
+}
+
+/*============================================================================*
+ * fence Fault Tests                                                          *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_fault_fence_init()                                                    *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE void test_fault_fence_init(void)
+{
+	test_assert(nanvix_fence_init(NULL, 1) < 0);
+	test_assert(nanvix_fence_init(NULL, 0) < 0);
+	test_assert(nanvix_fence_init(NULL, (THREAD_MAX + 1)) < 0);
+
+	test_assert(nanvix_fence_init(&fence, -1) < 0);
+	test_assert(nanvix_fence_init(&fence, 0) < 0);
+	test_assert(nanvix_fence_init(&fence, (THREAD_MAX + 1)) < 0);
+
+	test_assert(nanvix_fence_destroy(NULL) < 0);
+}
+
+/*----------------------------------------------------------------------------*
+ * test_fault_fence_operations()                                              *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE void test_fault_fence_operations(void)
+{
+	test_assert(nanvix_fence(NULL) < 0);
+}
+
+/*============================================================================*
+ * fence Stress Tests                                                         *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * test_stress_fence_sanity()                                                 *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Test sanity for fence variable.
+ *
+ * Tests fence variable behavior using two threads
+ */
+PRIVATE void test_stress_fence_sanity(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[NTHREADS];
+
+	nsyncs = 0;
+
+	test_assert(nanvix_fence_init(&fence, NTHREADS) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_create(&tids[i], fence_sanity, NULL) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+	test_assert(nanvix_fence_destroy(&fence) == 0);
+#endif
+}
+
+/*----------------------------------------------------------------------------*
+ * test_stress_fence_do()                                                     *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * @brief Test broadcast for condition variable.
+ *
+ * Tests condition variable behavior using two threads
+ */
+PRIVATE void test_stress_fence_do(void)
+{
+#if (THREAD_MAX > 2)
+	kthread_t tids[NTHREADS];
+
+	nsyncs = NSYNCS;
+
+	test_assert(nanvix_fence_init(&fence, NTHREADS) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_create(&tids[i], fence_do, NULL) == 0);
+
+		for (int i = 0; i < NTHREADS; i++)
+			test_assert(kthread_join(tids[i], NULL) == 0);
+
+	test_assert(nanvix_fence_destroy(&fence) == 0);
+#endif
+}
+
+/*============================================================================*
+ * Test Driver                                                                *
+ *============================================================================*/
+
+/**
+ * @brief API tests.
+ */
+PRIVATE struct test fences_tests_api[] = {
+	{ test_api_fence_init,   "[test][fence][api] Fence init                       [passed]" },
+	{ test_api_fence_sanity, "[test][fence][api] Sanity fence between two threads [passed]" },
+	{ test_api_fence_do,     "[test][fence][api] N syncs between two threads      [passed]" },
+	{ NULL,                  NULL                                                           },
+};
+
+/**
+ * @brief Fault tests.
+ */
+PRIVATE struct test fences_tests_fault[] = {
+	{ test_fault_fence_init,       "[test][fence][fault] Fence init [passed]" },
+	{ test_fault_fence_operations, "[test][fence][fault] Fence      [passed]" },
+	{ NULL,                        NULL                                       },
+};
+
+/**
+ * @brief Stress tests.
+ */
+PRIVATE struct test fences_tests_stress[] = {
+	{ test_stress_fence_sanity, "[test][fence][stress] Sanity fence between two threads [passed]" },
+	{ test_stress_fence_do,     "[test][fence][stress] N syncs between two threads      [passed]" },
+	{ NULL,                     NULL                                                              },
+};
+
+#endif  /* CORES_NUM */
+
+/**
+ * @brief Condition variable tests laucher
+ */
+PUBLIC void test_fence(void)
+{
+#if (CORES_NUM > 1)
+
+	spinlock_init(&flock);
+
+	/* API Tests */
+	nanvix_puts("--------------------------------------------------------------------------------");
+	for (int i = 0; fences_tests_api[i].test_fn != NULL; i++)
+	{
+		fences_tests_api[i].test_fn();
+		nanvix_puts(fences_tests_api[i].name);
+	}
+
+	/* Fault Tests */
+	nanvix_puts("--------------------------------------------------------------------------------");
+	for (int i = 0; fences_tests_fault[i].test_fn != NULL; i++)
+	{
+		fences_tests_fault[i].test_fn();
+		nanvix_puts(fences_tests_fault[i].name);
+	}
+
+	/* Stress Tests */
+	nanvix_puts("--------------------------------------------------------------------------------");
+	for (int i = 0; fences_tests_stress[i].test_fn != NULL; i++)
+	{
+		fences_tests_stress[i].test_fn();
+		nanvix_puts(fences_tests_stress[i].name);
+	}
+
+#endif  /* CORES_NUM */
+}
+

--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -1784,7 +1784,7 @@ PRIVATE struct test ikc_tests_stress[] = {
 	{ test_stress_ikc_thread_multiplexing_gather,           "[test][ikc][stress] IKC thread multiplexing gather            [passed]" },
 	{ test_stress_ikc_thread_multiplexing_pingpong,         "[test][ikc][stress] IKC thread multiplexing ping-pong         [passed]" },
 	{ test_stress_ikc_thread_multiplexing_pingpong_reverse, "[test][ikc][stress] IKC thread multiplexing ping-pong reverse [passed]" },
-#if (CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+#if (CORE_SUPPORTS_MULTITHREADING && __NANVIX_MICROKERNEL_DYNAMIC_SCHED)
 	{ test_stress_ikc_thread_multiplexing_affinity,         "[test][ikc][stress] IKC thread multiplexing affinity          [passed]" },
 	{ test_stress_ikc_thread_multiplexing_affinity_reverse, "[test][ikc][stress] IKC thread multiplexing affinity reverse  [passed]" },
 #endif

--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -56,7 +56,7 @@ PRIVATE char message_out[PORTAL_SIZE];
 /**
  * @brief Simple fence used for thread synchronization.
  */
-PRIVATE struct fence_t _fence;
+PRIVATE struct nanvix_fence _fence;
 
 /*============================================================================*
  * Stress Tests                                                               *
@@ -765,7 +765,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 					nports++;
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -776,7 +776,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 					test_assert(kportal_write(portalids[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -785,7 +785,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -802,7 +802,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 					nports++;
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -821,7 +821,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 						test_assert(msg[l] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -830,7 +830,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -845,7 +845,7 @@ PRIVATE void test_stress_ikc_thread_multiplexing_broadcast(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -895,7 +895,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 					nports++;
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -906,7 +906,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 					test_assert(kportal_write(portalids[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -915,7 +915,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -932,7 +932,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 					nports++;
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -951,7 +951,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 						test_assert(msg[l] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -960,7 +960,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -975,7 +975,7 @@ PRIVATE void test_stress_ikc_thread_multiplexing_gather(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -1027,7 +1027,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 				nports++;
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		if (local == MASTER_NODENUM)
@@ -1052,7 +1052,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 		else
@@ -1077,7 +1077,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 						test_assert(msg[l] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 
@@ -1089,7 +1089,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 			test_assert(kmailbox_unlink(inboxes[j]) == 0);
 		}
 
-		fence(&_fence);
+		nanvix_fence(&_fence);
 	}
 
 	return (NULL);
@@ -1103,7 +1103,7 @@ PRIVATE void test_stress_ikc_thread_multiplexing_pingpong(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -1155,7 +1155,7 @@ PRIVATE void * do_thread_multiplexing_pingpong_reverse(void * arg)
 				nports++;
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		if (local == MASTER_NODENUM)
@@ -1180,7 +1180,7 @@ PRIVATE void * do_thread_multiplexing_pingpong_reverse(void * arg)
 						test_assert(msg[l] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 		else
@@ -1205,7 +1205,7 @@ PRIVATE void * do_thread_multiplexing_pingpong_reverse(void * arg)
 					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 
@@ -1217,7 +1217,7 @@ PRIVATE void * do_thread_multiplexing_pingpong_reverse(void * arg)
 			test_assert(kmailbox_unlink(inboxes[j]) == 0);
 		}
 
-		fence(&_fence);
+		nanvix_fence(&_fence);
 	}
 
 	return (NULL);
@@ -1231,7 +1231,7 @@ PRIVATE void test_stress_ikc_thread_multiplexing_pingpong_reverse(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -1273,7 +1273,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				test_assert((portalids[nports] = kportal_open(local, local, j)) >= 0);
 				nports++;
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1284,7 +1284,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 					test_assert(kportal_write(portalids[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -1293,7 +1293,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -1310,7 +1310,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 					nports++;
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1329,7 +1329,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 						test_assert(msg[l] == 1);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -1338,7 +1338,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -1353,7 +1353,7 @@ PRIVATE void test_stress_ikc_thread_multiplexing_broadcast_local(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, 1, PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -1401,7 +1401,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 					nports++;
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1412,7 +1412,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 					test_assert(kportal_write(portalids[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -1421,7 +1421,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -1435,7 +1435,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				test_assert((portalids[nports] = kportal_create(local, j)) >= 0);
 				nports++;
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1454,7 +1454,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 						test_assert(msg[l] == 1);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
@@ -1463,7 +1463,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -1478,7 +1478,7 @@ PRIVATE void test_stress_ikc_thread_multiplexing_gather_local(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, 1, PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)

--- a/src/test/ikc.c
+++ b/src/test/ikc.c
@@ -43,6 +43,8 @@
 /**{*/
 #define TEST_THREAD_MAX       (CORES_NUM - 1)
 #define TEST_THREAD_IKCID_NUM ((TEST_THREAD_NPORTS / TEST_THREAD_MAX) + 1)
+#define TEST_CORE_AFFINITY    (1)
+#define TEST_THREAD_AFFINITY  (1 << TEST_CORE_AFFINITY)
 /**}*/
 
 /*============================================================================*
@@ -1117,6 +1119,140 @@ PRIVATE void test_stress_ikc_thread_multiplexing_pingpong(void)
 }
 
 /*============================================================================*
+ * Stress Test: IKC Thread Multiplexing Affinity                              *
+ *============================================================================*/
+
+/**
+ * @brief Stress Test: Portal Thread Multiplexing Affinity
+ */
+PRIVATE void * do_thread_multiplexing_affinity(void * arg)
+{
+	int tid;
+	int local;
+	int remote;
+	int nports;
+	int inboxes[TEST_THREAD_IKCID_NUM];
+	int outboxes[TEST_THREAD_IKCID_NUM];
+	int inportals[TEST_THREAD_IKCID_NUM];
+	int outportals[TEST_THREAD_IKCID_NUM];
+	char * msg;
+
+	/* Change affinity. */
+	test_assert(kthread_set_affinity(TEST_THREAD_AFFINITY) > 0);
+	test_assert(core_get_id() == TEST_CORE_AFFINITY);
+
+	tid = ((int)(intptr_t) arg);
+	msg = message_in[tid];
+
+	local = knode_get_num();
+	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	for (int i = 0; i < NSETUPS_AFFINITY; ++i)
+	{
+		nports = 0;
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
+		{
+			if (j == (tid + nports * TEST_THREAD_MAX))
+			{
+				test_assert((inboxes[nports] = kmailbox_create(local, j)) >= 0);
+				test_assert((outboxes[nports] = kmailbox_open(remote, j)) >= 0);
+				test_assert((inportals[nports] = kportal_create(local, j)) >= 0);
+				test_assert((outportals[nports] = kportal_open(local, remote, j)) >= 0);
+				nports++;
+			}
+
+			nanvix_fence(&_fence);
+		}
+
+		if (local == MASTER_NODENUM)
+		{
+			for (int j = 0; j < NCOMMS_AFFINITY; ++j)
+			{
+				for (int k = 0; k < nports; ++k)
+				{
+					kmemset(msg, (char) local, MAILBOX_SIZE);
+					test_assert(kmailbox_read(inboxes[k], msg, MAILBOX_SIZE) == MAILBOX_SIZE);
+					for (unsigned l = 0; l < MAILBOX_SIZE; ++l)
+						test_assert(msg[l] == remote);
+
+					kmemset(msg, (char) local, PORTAL_SIZE);
+					test_assert(kportal_allow(inportals[k], remote, (tid + k * TEST_THREAD_MAX)) >= 0);
+					test_assert(kportal_read(inportals[k], msg, PORTAL_SIZE) == PORTAL_SIZE);
+					for (unsigned l = 0; l < PORTAL_SIZE; ++l)
+						test_assert(msg[l] == remote);
+
+					test_assert(kmailbox_write(outboxes[k], message_out, MAILBOX_SIZE) == MAILBOX_SIZE);
+
+					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
+				}
+
+				nanvix_fence(&_fence);
+			}
+		}
+		else
+		{
+			for (int j = 0; j < NCOMMS_AFFINITY; ++j)
+			{
+				for (int k = 0; k < nports; ++k)
+				{
+					test_assert(kmailbox_write(outboxes[k], message_out, MAILBOX_SIZE) == MAILBOX_SIZE);
+
+					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
+
+					kmemset(msg, (char) local, MAILBOX_SIZE);
+					test_assert(kmailbox_read(inboxes[k], msg, MAILBOX_SIZE) == MAILBOX_SIZE);
+					for (unsigned l = 0; l < MAILBOX_SIZE; ++l)
+						test_assert(msg[l] == remote);
+
+					kmemset(msg, (char) local, PORTAL_SIZE);
+					test_assert(kportal_allow(inportals[k], remote, (tid + k * TEST_THREAD_MAX)) >= 0);
+					test_assert(kportal_read(inportals[k], msg, PORTAL_SIZE) == PORTAL_SIZE);
+					for (unsigned l = 0; l < PORTAL_SIZE; ++l)
+						test_assert(msg[l] == remote);
+				}
+
+				nanvix_fence(&_fence);
+			}
+		}
+
+		for (int j = 0; j < nports; ++j)
+		{
+			test_assert(kportal_close(outportals[j]) == 0);
+			test_assert(kportal_unlink(inportals[j]) == 0);
+			test_assert(kmailbox_close(outboxes[j]) == 0);
+			test_assert(kmailbox_unlink(inboxes[j]) == 0);
+		}
+
+		nanvix_fence(&_fence);
+	}
+
+	return (NULL);
+}
+
+/**
+ * @brief Stress Test: IKC Thread Multiplexing Affinity
+ */
+PRIVATE void test_stress_ikc_thread_multiplexing_affinity(void)
+{
+	kthread_t tid[TEST_THREAD_MAX - 1];
+
+	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
+
+	/* Create threads. */
+	for (int i = 1; i < TEST_THREAD_MAX; ++i)
+		test_assert(kthread_create(&tid[i - 1], do_thread_multiplexing_affinity, ((void *)(intptr_t) i)) == 0);
+
+	do_thread_multiplexing_affinity(0);
+
+	/* Join threads. */
+	for (int i = 1; i < TEST_THREAD_MAX; ++i)
+		test_assert(kthread_join(tid[i - 1], NULL) == 0);
+
+	test_assert(kthread_set_affinity(KTHREAD_AFFINITY_DEFAULT) == TEST_THREAD_AFFINITY);
+}
+
+/*============================================================================*
  * Stress Test: Portal Thread Multiplexing Ping-Pong Reverse                  *
  *============================================================================*/
 
@@ -1242,6 +1378,140 @@ PRIVATE void test_stress_ikc_thread_multiplexing_pingpong_reverse(void)
 	/* Join threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
 		test_assert(kthread_join(tid[i - 1], NULL) == 0);
+}
+
+/*============================================================================*
+ * Stress Test: IKC Thread Multiplexing Affinity Reverse                      *
+ *============================================================================*/
+
+/**
+ * @brief Stress Test: Portal Thread Multiplexing Affinity Reverse
+ */
+PRIVATE void * do_thread_multiplexing_affinity_reverse(void * arg)
+{
+	int tid;
+	int local;
+	int remote;
+	int nports;
+	int inboxes[TEST_THREAD_IKCID_NUM];
+	int outboxes[TEST_THREAD_IKCID_NUM];
+	int inportals[TEST_THREAD_IKCID_NUM];
+	int outportals[TEST_THREAD_IKCID_NUM];
+	char * msg;
+
+	/* Change affinity. */
+	test_assert(kthread_set_affinity(TEST_THREAD_AFFINITY) > 0);
+	test_assert(core_get_id() == TEST_CORE_AFFINITY);
+
+	tid = ((int)(intptr_t) arg);
+	msg = message_in[tid];
+
+	local = knode_get_num();
+	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	for (int i = 0; i < NSETUPS_AFFINITY; ++i)
+	{
+		nports = 0;
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
+		{
+			if (j == (tid + nports * TEST_THREAD_MAX))
+			{
+				test_assert((inboxes[nports] = kmailbox_create(local, j)) >= 0);
+				test_assert((outboxes[nports] = kmailbox_open(remote, j)) >= 0);
+				test_assert((inportals[nports] = kportal_create(local, j)) >= 0);
+				test_assert((outportals[nports] = kportal_open(local, remote, j)) >= 0);
+				nports++;
+			}
+
+			nanvix_fence(&_fence);
+		}
+
+		if (local == MASTER_NODENUM)
+		{
+			for (int j = 0; j < NCOMMS_AFFINITY; ++j)
+			{
+				for (int k = 0; k < nports; ++k)
+				{
+					kmemset(msg, (char) local, MAILBOX_SIZE);
+					test_assert(kmailbox_read(inboxes[k], msg, MAILBOX_SIZE) == MAILBOX_SIZE);
+					for (unsigned l = 0; l < MAILBOX_SIZE; ++l)
+						test_assert(msg[l] == remote);
+
+					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
+
+					test_assert(kmailbox_write(outboxes[k], message_out, MAILBOX_SIZE) == MAILBOX_SIZE);
+
+					kmemset(msg, (char) local, PORTAL_SIZE);
+					test_assert(kportal_allow(inportals[k], remote, (tid + k * TEST_THREAD_MAX)) >= 0);
+					test_assert(kportal_read(inportals[k], msg, PORTAL_SIZE) == PORTAL_SIZE);
+					for (unsigned l = 0; l < PORTAL_SIZE; ++l)
+						test_assert(msg[l] == remote);
+				}
+
+				nanvix_fence(&_fence);
+			}
+		}
+		else
+		{
+			for (int j = 0; j < NCOMMS_AFFINITY; ++j)
+			{
+				for (int k = 0; k < nports; ++k)
+				{
+					test_assert(kmailbox_write(outboxes[k], message_out, MAILBOX_SIZE) == MAILBOX_SIZE);
+
+					kmemset(msg, (char) local, PORTAL_SIZE);
+					test_assert(kportal_allow(inportals[k], remote, (tid + k * TEST_THREAD_MAX)) >= 0);
+					test_assert(kportal_read(inportals[k], msg, PORTAL_SIZE) == PORTAL_SIZE);
+					for (unsigned l = 0; l < PORTAL_SIZE; ++l)
+						test_assert(msg[l] == remote);
+
+					kmemset(msg, (char) local, MAILBOX_SIZE);
+					test_assert(kmailbox_read(inboxes[k], msg, MAILBOX_SIZE) == MAILBOX_SIZE);
+					for (unsigned l = 0; l < MAILBOX_SIZE; ++l)
+						test_assert(msg[l] == remote);
+
+					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
+				}
+
+				nanvix_fence(&_fence);
+			}
+		}
+
+		for (int j = 0; j < nports; ++j)
+		{
+			test_assert(kportal_close(outportals[j]) == 0);
+			test_assert(kportal_unlink(inportals[j]) == 0);
+			test_assert(kmailbox_close(outboxes[j]) == 0);
+			test_assert(kmailbox_unlink(inboxes[j]) == 0);
+		}
+
+		nanvix_fence(&_fence);
+	}
+
+	return (NULL);
+}
+
+/**
+ * @brief Stress Test: IKC Thread Multiplexing Affinity Reverse
+ */
+PRIVATE void test_stress_ikc_thread_multiplexing_affinity_reverse(void)
+{
+	kthread_t tid[TEST_THREAD_MAX - 1];
+
+	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
+
+	/* Create threads. */
+	for (int i = 1; i < TEST_THREAD_MAX; ++i)
+		test_assert(kthread_create(&tid[i - 1], do_thread_multiplexing_affinity_reverse, ((void *)(intptr_t) i)) == 0);
+
+	do_thread_multiplexing_affinity_reverse(0);
+
+	/* Join threads. */
+	for (int i = 1; i < TEST_THREAD_MAX; ++i)
+		test_assert(kthread_join(tid[i - 1], NULL) == 0);
+
+	test_assert(kthread_set_affinity(KTHREAD_AFFINITY_DEFAULT) == TEST_THREAD_AFFINITY);
 }
 
 /*============================================================================*
@@ -1514,6 +1784,10 @@ PRIVATE struct test ikc_tests_stress[] = {
 	{ test_stress_ikc_thread_multiplexing_gather,           "[test][ikc][stress] IKC thread multiplexing gather            [passed]" },
 	{ test_stress_ikc_thread_multiplexing_pingpong,         "[test][ikc][stress] IKC thread multiplexing ping-pong         [passed]" },
 	{ test_stress_ikc_thread_multiplexing_pingpong_reverse, "[test][ikc][stress] IKC thread multiplexing ping-pong reverse [passed]" },
+#if (CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+	{ test_stress_ikc_thread_multiplexing_affinity,         "[test][ikc][stress] IKC thread multiplexing affinity          [passed]" },
+	{ test_stress_ikc_thread_multiplexing_affinity_reverse, "[test][ikc][stress] IKC thread multiplexing affinity reverse  [passed]" },
+#endif
 	{ test_stress_ikc_thread_multiplexing_broadcast_local,  "[test][ikc][stress] IKC thread multiplexing broadcast local   [passed]" },
 	{ test_stress_ikc_thread_multiplexing_gather_local,     "[test][ikc][stress] IKC thread multiplexing gather local      [passed]" },
 	{ NULL,                                                  NULL                                                                    },

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -2492,13 +2492,13 @@ PRIVATE struct test mailbox_tests_stress[] = {
 	{ test_stress_mailbox_multiplexing_gather,                 "[test][mailbox][stress] mailbox multiplexing gather                 [passed]" },
 	{ test_stress_mailbox_multiplexing_pingpong,               "[test][mailbox][stress] mailbox multiplexing ping-pong              [passed]" },
 	{ test_stress_mailbox_thread_specified_source,             "[test][mailbox][stress] mailbox thread specified source             [passed]" },
-#if (CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+#if (CORE_SUPPORTS_MULTITHREADING && __NANVIX_MICROKERNEL_DYNAMIC_SCHED)
 	{ test_stress_mailbox_thread_specified_affinity,           "[test][mailbox][stress] mailbox thread specified affinity           [passed]" },
 #endif
 	{ test_stress_mailbox_thread_multiplexing_broadcast,       "[test][mailbox][stress] mailbox thread multiplexing broadcast       [passed]" },
 	{ test_stress_mailbox_thread_multiplexing_gather,          "[test][mailbox][stress] mailbox thread multiplexing gather          [passed]" },
 	{ test_stress_mailbox_thread_multiplexing_pingpong,        "[test][mailbox][stress] mailbox thread multiplexing ping-pong       [passed]" },
-#if (CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+#if (CORE_SUPPORTS_MULTITHREADING && __NANVIX_MICROKERNEL_DYNAMIC_SCHED)
 	{ test_stress_mailbox_thread_multiplexing_affinity,        "[test][mailbox][stress] mailbox thread multiplexing affinity        [passed]" },
 #endif
 	{ test_stress_mailbox_thread_multiplexing_broadcast_local, "[test][mailbox][stress] mailbox thread multiplexing broadcast local [passed]" },

--- a/src/test/kmailbox.c
+++ b/src/test/kmailbox.c
@@ -79,7 +79,7 @@
 /**
  * @brief Simple fence used for thread synchronization.
  */
-PRIVATE struct fence_t _fence;
+PRIVATE struct nanvix_fence _fence;
 
 /*============================================================================*
  * API Test: Create Unlink                                                    *
@@ -1666,7 +1666,7 @@ PRIVATE void * do_thread_specified_source(void * arg)
 			if (tid == i)
 				test_assert((mbxid = kmailbox_open(remote, 0)) >= 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		/* Send some messages to the master node. */
@@ -1733,7 +1733,7 @@ static void test_stress_mailbox_thread_specified_source(void)
 
 	if (local == SLAVE_NODENUM)
 	{
-		fence_init(&_fence, TEST_THREAD_SPECIFIED);
+		nanvix_fence_init(&_fence, TEST_THREAD_SPECIFIED);
 
 		/* Create threads. */
 		for (int i = 1; i < TEST_THREAD_SPECIFIED; ++i)
@@ -1779,7 +1779,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 				if (j == (tid + nports * TEST_THREAD_MAX))
 					test_assert((mbxids[nports++] = kmailbox_open(remote, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1787,13 +1787,13 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 				for (int k = 0; k < nports; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 				
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -1806,7 +1806,7 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 				if (j == (tid + nports * TEST_THREAD_MAX))
 					test_assert((mbxids[nports++] = kmailbox_create(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1818,13 +1818,13 @@ PRIVATE void * do_thread_multiplexing_broadcast(void * arg)
 					test_assert(message[0] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -1838,7 +1838,7 @@ PRIVATE void test_stress_mailbox_thread_multiplexing_broadcast(void)
 {
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -1884,7 +1884,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 				if (j == (tid + nports * TEST_THREAD_MAX))
 					test_assert((mbxids[nports++] = kmailbox_open(remote, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1892,13 +1892,13 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 				for (int k = 0; k < nports; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -1911,7 +1911,7 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 				if (j == (tid + nports * TEST_THREAD_MAX))
 					test_assert((mbxids[nports++] = kmailbox_create(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1923,13 +1923,13 @@ PRIVATE void * do_thread_multiplexing_gather(void * arg)
 					test_assert(message[0] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -1943,7 +1943,7 @@ PRIVATE void test_stress_mailbox_thread_multiplexing_gather(void)
 {
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -1993,7 +1993,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 				nports++;
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		if (local == MASTER_NODENUM)
@@ -2009,7 +2009,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 					test_assert(kmailbox_write(outboxes[k], msg_out, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 		else
@@ -2025,7 +2025,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 					test_assert(msg_in[0] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 
@@ -2035,7 +2035,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 			test_assert(kmailbox_unlink(inboxes[j]) == 0);
 		}
 
-		fence(&_fence);
+		nanvix_fence(&_fence);
 	}
 
 	return (NULL);
@@ -2048,7 +2048,7 @@ PRIVATE void test_stress_mailbox_thread_multiplexing_pingpong(void)
 {
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -2091,7 +2091,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 			{
 				test_assert((mbxids[nports++] = kmailbox_open(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2099,13 +2099,13 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				for (int k = 0; k < nports; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 				
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -2118,7 +2118,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				if (j == ((tid - 1) + nports * (TEST_THREAD_MAX - 1)))
 					test_assert((mbxids[nports++] = kmailbox_create(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2130,13 +2130,13 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 					test_assert(message[0] == 1);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -2150,7 +2150,7 @@ PRIVATE void test_stress_mailbox_thread_multiplexing_broadcast_local(void)
 {
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -2195,7 +2195,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				if (j == ((tid - 1) + nports * (TEST_THREAD_MAX - 1)))
 					test_assert((mbxids[nports++] = kmailbox_open(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2203,13 +2203,13 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				for (int k = 0; k < nports; ++k)
 					test_assert(kmailbox_write(mbxids[k], message, KMAILBOX_MESSAGE_SIZE) == KMAILBOX_MESSAGE_SIZE);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_close(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -2221,7 +2221,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 			{
 				test_assert((mbxids[nports++] = kmailbox_create(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2233,13 +2233,13 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 					test_assert(message[0] == 1);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kmailbox_unlink(mbxids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -2253,7 +2253,7 @@ PRIVATE void test_stress_mailbox_thread_multiplexing_gather_local(void)
 {
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -82,7 +82,7 @@ PRIVATE char message_out[PORTAL_SIZE];
 /**
  * @brief Simple fence used for thread synchronization.
  */
-PRIVATE struct fence_t _fence;
+PRIVATE struct nanvix_fence _fence;
 
 /*============================================================================*
  * API Test: Create Unlink                                                    *
@@ -1985,7 +1985,7 @@ PRIVATE void test_stress_do_sender_thread(int tid, int local, int remote)
 			if (j == (tid + nports * TEST_THREAD_MAX))
 				test_assert((portalids[nports++] = kportal_open(local, remote, j)) >= 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -1993,13 +1993,13 @@ PRIVATE void test_stress_do_sender_thread(int tid, int local, int remote)
 			for (int k = 0; k < nports; ++k)
 				test_assert(kportal_write(portalids[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		for (int j = 0; j < nports; ++j)
 			test_assert(kportal_close(portalids[j]) == 0);
 
-		fence(&_fence);
+		nanvix_fence(&_fence);
 	}
 }
 
@@ -2019,7 +2019,7 @@ PRIVATE void test_stress_do_receiver_thread(int tid, int local, int remote)
 			if (j == (tid + nports * TEST_THREAD_MAX))
 				test_assert((portalids[nports++] = kportal_create(local, j)) >= 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2033,13 +2033,13 @@ PRIVATE void test_stress_do_receiver_thread(int tid, int local, int remote)
 					test_assert(msg[l] == remote);
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		for (int j = 0; j < nports; ++j)
 			test_assert(kportal_unlink(portalids[j]) == 0);
 
-		fence(&_fence);
+		nanvix_fence(&_fence);
 	}
 }
 
@@ -2061,7 +2061,7 @@ PRIVATE void test_stress_portal_thread_multiplexing_broadcast(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -2099,7 +2099,7 @@ PRIVATE void test_stress_portal_thread_multiplexing_gather(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -2147,7 +2147,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 				nports++;
 			}
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 
 		if (local == MASTER_NODENUM)
@@ -2165,7 +2165,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 		else
@@ -2183,7 +2183,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 						test_assert(msg[l] == remote);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 		}
 
@@ -2193,7 +2193,7 @@ PRIVATE void * do_thread_multiplexing_pingpong(void * arg)
 			test_assert(kportal_unlink(inportals[j]) == 0);
 		}
 
-		fence(&_fence);
+		nanvix_fence(&_fence);
 	}
 
 	return (NULL);
@@ -2207,7 +2207,7 @@ PRIVATE void test_stress_portal_thread_multiplexing_pingpong(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -2246,7 +2246,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 			{
 				test_assert((portalids[nports++] = kportal_open(local, local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2254,13 +2254,13 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				for (int k = 0; k < nports; ++k)
 					test_assert(kportal_write(portalids[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kportal_close(portalids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -2273,7 +2273,7 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 				if (j == ((tid - 1) + nports * (TEST_THREAD_MAX - 1)))
 					test_assert((portalids[nports++] = kportal_create(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2287,13 +2287,13 @@ PRIVATE void * do_thread_multiplexing_broadcast_local(void * arg)
 						test_assert(msg[l] == 1);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -2308,7 +2308,7 @@ PRIVATE void test_stress_portal_thread_multiplexing_broadcast_local(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, 1, PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)
@@ -2351,7 +2351,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				if (j == ((tid - 1) + nports * (TEST_THREAD_MAX - 1)))
 					test_assert((portalids[nports++] = kportal_open(local, local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2359,13 +2359,13 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 				for (int k = 0; k < nports; ++k)
 					test_assert(kportal_write(portalids[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kportal_close(portalids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 	else
@@ -2377,7 +2377,7 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 			{
 				test_assert((portalids[nports++] = kportal_create(local, j)) >= 0);
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < NCOMMUNICATIONS; ++j)
@@ -2391,13 +2391,13 @@ PRIVATE void * do_thread_multiplexing_gather_local(void * arg)
 						test_assert(msg[l] == 1);
 				}
 
-				fence(&_fence);
+				nanvix_fence(&_fence);
 			}
 
 			for (int j = 0; j < nports; ++j)
 				test_assert(kportal_unlink(portalids[j]) == 0);
 
-			fence(&_fence);
+			nanvix_fence(&_fence);
 		}
 	}
 
@@ -2412,7 +2412,7 @@ PRIVATE void test_stress_portal_thread_multiplexing_gather_local(void)
 	kthread_t tid[TEST_THREAD_MAX - 1];
 
 	kmemset(message_out, 1, PORTAL_SIZE);
-	fence_init(&_fence, TEST_THREAD_MAX);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
 
 	/* Create threads. */
 	for (int i = 1; i < TEST_THREAD_MAX; ++i)

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -69,6 +69,8 @@
 /**{*/
 #define TEST_THREAD_MAX          (CORES_NUM - 1)
 #define TEST_THREAD_PORTALID_NUM ((TEST_THREAD_NPORTS / TEST_THREAD_MAX) + 1)
+#define TEST_CORE_AFFINITY       (1)
+#define TEST_THREAD_AFFINITY     (1 << TEST_CORE_AFFINITY)
 /**}*/
 
 /*============================================================================*
@@ -2221,6 +2223,121 @@ PRIVATE void test_stress_portal_thread_multiplexing_pingpong(void)
 }
 
 /*============================================================================*
+ * Stress Test: Portal Thread Multiplexing Affinity                           *
+ *============================================================================*/
+
+#define PPORT(x) (tid + x * TEST_THREAD_MAX)
+
+/**
+ * @brief Stress Test: Portal Thread Multiplexing Affinity
+ */
+PRIVATE void * do_thread_multiplexing_affinity(void * arg)
+{
+	int tid;
+	int local;
+	int remote;
+	int nports;
+	int inportals[TEST_THREAD_PORTALID_NUM];
+	int outportals[TEST_THREAD_PORTALID_NUM];
+	char * msg;
+
+	test_assert(kthread_set_affinity(TEST_THREAD_AFFINITY) > 0);
+	test_assert(core_get_id() == TEST_CORE_AFFINITY);
+
+	tid = ((int)(intptr_t) arg);
+	msg = message_in[tid];
+
+	local  = knode_get_num();
+	remote = local == MASTER_NODENUM ? SLAVE_NODENUM : MASTER_NODENUM;
+
+	for (int i = 0; i < NSETUPS_AFFINITY; ++i)
+	{
+		nports = 0;
+		for (int j = 0; j < TEST_THREAD_NPORTS; ++j)
+		{
+			if (j == (tid + nports * TEST_THREAD_MAX))
+			{
+				test_assert((inportals[nports] = kportal_create(local, j)) >= 0);
+				test_assert((outportals[nports] = kportal_open(local, remote, j)) >= 0);
+				nports++;
+			}
+
+			nanvix_fence(&_fence);
+		}
+
+		if (local == MASTER_NODENUM)
+		{
+			for (int j = 0; j < NCOMMS_AFFINITY; ++j)
+			{
+				for (int k = 0; k < nports; ++k)
+				{
+					kmemset(msg, -1, PORTAL_SIZE);
+					test_assert(kportal_allow(inportals[k], remote, (tid + k * TEST_THREAD_MAX)) >= 0);
+					test_assert(kportal_read(inportals[k], msg, PORTAL_SIZE) == PORTAL_SIZE);
+					for (int l = 0; l < PORTAL_SIZE; ++l)
+						test_assert(msg[l] == remote);
+
+					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
+				}
+
+				nanvix_fence(&_fence);
+			}
+		}
+		else
+		{
+			for (int j = 0; j < NCOMMS_AFFINITY; ++j)
+			{
+				for (int k = 0; k < nports; ++k)
+				{
+					test_assert(kportal_write(outportals[k], message_out, PORTAL_SIZE) == PORTAL_SIZE);
+
+					kmemset(msg, -1, PORTAL_SIZE);
+					test_assert(kportal_allow(inportals[k], remote, (tid + k * TEST_THREAD_MAX)) >= 0);
+					test_assert(kportal_read(inportals[k], msg, PORTAL_SIZE) == PORTAL_SIZE);
+					for (int l = 0; l < PORTAL_SIZE; ++l)
+						test_assert(msg[l] == remote);
+				}
+
+				nanvix_fence(&_fence);
+			}
+		}
+
+		for (int j = 0; j < nports; ++j)
+		{
+			test_assert(kportal_close(outportals[j]) == 0);
+			test_assert(kportal_unlink(inportals[j]) == 0);
+		}
+
+		nanvix_fence(&_fence);
+	}
+
+	return (NULL);
+}
+
+/**
+ * @brief Stress Test: Portal Thread Multiplexing Affinity
+ */
+PRIVATE void test_stress_portal_thread_multiplexing_affinity(void)
+{
+	kthread_t tid[TEST_THREAD_MAX - 1];
+
+	kmemset(message_out, (char) knode_get_num(), PORTAL_SIZE);
+	nanvix_fence_init(&_fence, TEST_THREAD_MAX);
+
+	/* Create threads. */
+	for (int i = 1; i < TEST_THREAD_MAX; ++i)
+		test_assert(kthread_create(&tid[i - 1], do_thread_multiplexing_affinity, ((void *)(intptr_t) i)) == 0);
+
+	do_thread_multiplexing_affinity(0);
+
+	/* Join threads. */
+	for (int i = 1; i < TEST_THREAD_MAX; ++i)
+		test_assert(kthread_join(tid[i - 1], NULL) == 0);
+
+	test_assert(kthread_set_affinity(KTHREAD_AFFINITY_DEFAULT) == TEST_THREAD_AFFINITY);
+}
+
+/*============================================================================*
  * Stress Test: Portal Thread Multiplexing Broadcast Local                    *
  *============================================================================*/
 
@@ -2500,6 +2617,9 @@ PRIVATE struct test portal_tests_stress[] = {
 	{ test_stress_portal_thread_multiplexing_broadcast,       "[test][portal][stress] portal thread multiplexing broadcast       [passed]" },
 	{ test_stress_portal_thread_multiplexing_gather,          "[test][portal][stress] portal thread multiplexing gather          [passed]" },
 	{ test_stress_portal_thread_multiplexing_pingpong,        "[test][portal][stress] portal thread multiplexing ping-pong       [passed]" },
+#if (CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+	{ test_stress_portal_thread_multiplexing_affinity,        "[test][portal][stress] portal thread multiplexing affinity        [passed]" },
+#endif
 	{ test_stress_portal_thread_multiplexing_broadcast_local, "[test][portal][stress] portal thread multiplexing broadcast local [passed]" },
 	{ test_stress_portal_thread_multiplexing_gather_local,    "[test][portal][stress] portal thread multiplexing gather local    [passed]" },
 	{ NULL,                                                    NULL                                                                        },

--- a/src/test/kportal.c
+++ b/src/test/kportal.c
@@ -2617,7 +2617,7 @@ PRIVATE struct test portal_tests_stress[] = {
 	{ test_stress_portal_thread_multiplexing_broadcast,       "[test][portal][stress] portal thread multiplexing broadcast       [passed]" },
 	{ test_stress_portal_thread_multiplexing_gather,          "[test][portal][stress] portal thread multiplexing gather          [passed]" },
 	{ test_stress_portal_thread_multiplexing_pingpong,        "[test][portal][stress] portal thread multiplexing ping-pong       [passed]" },
-#if (CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+#if (CORE_SUPPORTS_MULTITHREADING && __NANVIX_MICROKERNEL_DYNAMIC_SCHED)
 	{ test_stress_portal_thread_multiplexing_affinity,        "[test][portal][stress] portal thread multiplexing affinity        [passed]" },
 #endif
 	{ test_stress_portal_thread_multiplexing_broadcast_local, "[test][portal][stress] portal thread multiplexing broadcast local [passed]" },

--- a/src/test/ksync.c
+++ b/src/test/ksync.c
@@ -32,18 +32,6 @@
 #if __TARGET_HAS_SYNC
 
 /**
- * @brief Test's parameters
- */
-#define NR_NODES       2
-#define NR_NODES_MAX   PROCESSOR_NOC_NODES_NUM
-#define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-#else
-	#define SLAVE_NODENUM  1
-#endif
-
-/**
  * @brief Auxiliar array
  */
 int nodenums[NR_NODES] = {
@@ -486,7 +474,7 @@ void test_fault_sync_invalid_create(void)
 	test_assert((ksync_create(nodes, -1, SYNC_ONE_TO_ALL)) == -EINVAL);
 	test_assert((ksync_create(nodes, 0, SYNC_ONE_TO_ALL)) == -EINVAL);
 	test_assert((ksync_create(nodes, 1, SYNC_ONE_TO_ALL)) == -EINVAL);
-	test_assert((ksync_create(nodes, NR_NODES_MAX + 1, SYNC_ONE_TO_ALL)) == -EINVAL);
+	test_assert((ksync_create(nodes, MAX_NUM_NODES + 1, SYNC_ONE_TO_ALL)) == -EINVAL);
 	test_assert((ksync_create(nodes, NR_NODES, -1)) == -EINVAL);
 	nodes[1] = nodes[0];
 	test_assert((ksync_create(nodes, NR_NODES, SYNC_ONE_TO_ALL)) == -EINVAL);
@@ -617,7 +605,7 @@ void test_fault_sync_invalid_open(void)
 	test_assert((ksync_open(nodes, -1, SYNC_ONE_TO_ALL)) == -EINVAL);
 	test_assert((ksync_open(nodes, 0, SYNC_ONE_TO_ALL)) == -EINVAL);
 	test_assert((ksync_open(nodes, 1, SYNC_ONE_TO_ALL)) == -EINVAL);
-	test_assert((ksync_open(nodes, NR_NODES_MAX + 1, SYNC_ONE_TO_ALL)) == -EINVAL);
+	test_assert((ksync_open(nodes, MAX_NUM_NODES + 1, SYNC_ONE_TO_ALL)) == -EINVAL);
 	test_assert((ksync_open(nodes, NR_NODES, -1)) == -EINVAL);
 	nodes[1] = nodes[0];
 	test_assert((ksync_open(nodes, NR_NODES, SYNC_ONE_TO_ALL)) == -EINVAL);

--- a/src/test/kthread.c
+++ b/src/test/kthread.c
@@ -273,7 +273,7 @@ static void test_api_kthread_yield(void)
  */
 static void test_api_kthread_affinity(void)
 {
-#if ((THREAD_MAX > 1) && CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+#if ((THREAD_MAX > 1) && CORE_SUPPORTS_MULTITHREADING && __NANVIX_MICROKERNEL_DYNAMIC_SCHED)
 
 	kthread_t tid;
 
@@ -493,7 +493,7 @@ static void test_fault_kthread_join_bad(void)
  */
 static void test_fault_kthread_affinity(void)
 {
-#if (CORE_SUPPORTS_MULTITHREADING && !__NANVIX_MICROKERNEL_STATIC_SCHED)
+#if (CORE_SUPPORTS_MULTITHREADING && __NANVIX_MICROKERNEL_DYNAMIC_SCHED)
 
 	test_assert(kthread_set_affinity(0) < 0);
 	test_assert(kthread_set_affinity(1 << CORES_NUM) < 0);

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -82,11 +82,10 @@ size_t strlen(const char *str)
  */
 void nanvix_puts(const char *str)
 {
-	size_t len;
+	if (knode_get_num() != MASTER_NODENUM)
+		return;
 
-	len = strlen(str);
-
-	nanvix_write(0, str, len);
+	nanvix_write(0, str, strlen(str));
 }
 
 /*============================================================================*
@@ -126,18 +125,25 @@ void ___start(int argc, const char *argv[])
 	/* Only involved nodes. */
 	if (index >= 0)
 	{
-		if (nodenum == 0)
+#ifndef __mppa256__
+		if (nodenum == MASTER_NODENUM)
 		{
+#endif
+
 			test_kframe_mgmt();
 			test_page_mgmt();
+
 			test_thread_mgmt();
 			test_thread_sleep();
-		#if (CORES_NUM > 1)
 			test_mutex();
 			test_semaphore();
 			test_condition_variables();
-		#endif
 			test_fence();
+
+#ifdef __mppa256__
+		if (nodenum == MASTER_NODENUM)
+		{
+#endif
 
 		#ifndef __unix64__
 			test_perf();

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -137,6 +137,7 @@ void ___start(int argc, const char *argv[])
 			test_semaphore();
 			test_condition_variables();
 		#endif
+			test_fence();
 
 		#ifndef __unix64__
 			test_perf();
@@ -187,3 +188,4 @@ void ___start(int argc, const char *argv[])
 	kshutdown();
 	UNREACHABLE();
 }
+

--- a/src/test/mutex.c
+++ b/src/test/mutex.c
@@ -473,11 +473,15 @@ PRIVATE struct test mutex_tests_stress[] = {
 	{ NULL,                          NULL                                             },
 };
 
+#endif  /* CORES_NUM */
+
 /**
  * @brief Mutex test laucher.
  */
 PUBLIC void test_mutex(void)
 {
+#if (CORES_NUM > 1)
+
 	/* API Tests */
 	nanvix_puts("--------------------------------------------------------------------------------");
 	for (int i = 0; mutex_tests_api[i].test_fn != NULL; i++)
@@ -501,7 +505,7 @@ PUBLIC void test_mutex(void)
 		mutex_tests_stress[i].test_fn();
 		nanvix_puts(mutex_tests_stress[i].name);
 	}
-}
 
 #endif  /* CORES_NUM */
+}
 

--- a/src/test/sleep.c
+++ b/src/test/sleep.c
@@ -40,7 +40,11 @@
 /**
  * @brief Number of trials.
  */
-#define NTRIALS 1000
+#if UTEST_SLEEP_STRESS
+	#define NTRIALS 1000
+#else
+	#define NTRIALS 100
+#endif
 
 #if (THREAD_MAX > 2)
 

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -26,41 +26,51 @@
 #define _TEST_H_
 
 	#include <nanvix/sys/thread.h>
+	#include <nanvix/sys/mutex.h>
+	#include <nanvix/sys/noc.h>
 
 	/**
-     * @brief Test's parameters
-     */
+	 * @brief Test's parameters
+	 */
 	/**@{*/
-    #define NR_NODES       2
-    #define MASTER_NODENUM 0
-#ifdef __mppa256__
-	#define SLAVE_NODENUM  8
-	#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
-#else
-	#define SLAVE_NODENUM  1
+	#define NR_NODES           2
+#if (PROCESSOR_IS_MULTICLUSTER)
+		#define MASTER_NODENUM     PROCESSOR_NODENUM_MASTER
+	#ifdef __mppa256__
+		#define SLAVE_NODENUM      PROCESSOR_NODENUM_LEADER
+		#define TEST_THREAD_NPORTS (K1BDP_CORES_NUM - 1)
+	#else /* !__mppa256__ */
+		#define SLAVE_NODENUM      (PROCESSOR_NODENUM_MASTER + 1)
+		#define TEST_THREAD_NPORTS (THREAD_MAX)
+	#endif /* __mppa256__ */
+#else /* !PROCESSOR_IS_MULTICLUSTER */
+	#define MASTER_NODENUM     0
+	#define SLAVE_NODENUM      1
 	#define TEST_THREAD_NPORTS (THREAD_MAX)
-#endif
-    #define NSETUPS 10
-    #define NCOMMUNICATIONS 100
+#endif /* PROCESSOR_IS_MULTICLUSTER */
+	#define NSETUPS            10
+	#define NCOMMUNICATIONS    25
+	#define NSETUPS_AFFINITY    1
+	#define NCOMMS_AFFINITY     2
 	/**@}*/
 
-    /**
-     * @name Portal sizes.
-     */
+	/**
+	 * @name Portal sizes.
+	 */
 	/**@{*/
-    #define PORTAL_SIZE       (1 * KB)                             /**< Small size. */
+	#define PORTAL_SIZE       (1 * KB)                             /**< Small size. */
 	#define PORTAL_SIZE_LARGE (HAL_PORTAL_DATA_SIZE + PORTAL_SIZE) /**< Large size. */
 	/**@}*/
 
 	/**
      * @brief Portal message size
      */
-    #define MAILBOX_SIZE (KMAILBOX_MESSAGE_SIZE)
+    #define MAILBOX_SIZE KMAILBOX_MESSAGE_SIZE
 
-    /**
-     * @brief Max number of nodes involved.
-     */
-    #define MAX_NUM_NODES PROCESSOR_NOC_NODES_NUM
+	/**
+	 * @brief Max number of nodes involved.
+	 */
+	#define MAX_NUM_NODES PROCESSOR_NOC_NODES_NUM
 
 	/**
 	 * @brief Number of iterations in stress tests.
@@ -92,15 +102,17 @@
 	extern void nanvix_puts(const char *str);
 
 #if __TARGET_HAS_SYNC
-    /**
-     * @name Barrier functions
-     */
-    /**@{*/
+
+	/**
+	 * @name Barrier functions
+	 */
+	/**@{*/
 	extern void test_delay(int times, uint64_t cycles);
-    extern void test_barrier_nodes_setup(const int * nodes, int nnodes, int is_master);
-    extern void test_barrier_nodes(void);
-    extern void test_barrier_nodes_cleanup(void);
-    /**@}*/
+	extern void test_barrier_nodes_setup(const int * nodes, int nnodes, int is_master);
+	extern void test_barrier_nodes(void);
+	extern void test_barrier_nodes_cleanup(void);
+	/**@}*/
+
 #endif /* __TARGET_HAS_SYNC */
 
 	/**
@@ -110,6 +122,7 @@
 	extern void test_kframe_mgmt(void);
 	extern void test_page_mgmt(void);
 	extern void test_thread_mgmt(void);
+	extern void test_task_mgmt(void);
 	extern void test_excp_mgmt(void);
 	extern void test_thread_sleep(void);
 	extern void test_condition_variables(void);
@@ -123,6 +136,7 @@
 	extern void test_portal(void);
 	extern void test_ikc(void);
 	extern void test_semaphore(void);
+	extern void test_fence(void);
 
 	/**@}*/
 
@@ -143,8 +157,8 @@
 	}
 
 	/**
-     * @brief Horizontal line.
-     */
-    extern const char *HLINE;
+	 * @brief Horizontal line.
+	 */
+	extern const char *HLINE;
 
 #endif /* _TEST_H_  */


### PR DESCRIPTION
In this PR, I introduce tests to evaluate and stimulate preemptive threads through scheduling and affinities with the nuclei.

In addition, we correct some performance bugs of synchronization abtractions between threads and their interfaces.

Finally, pack problems with thread mapping for ports in IKC standards.

## Dependency with a PR on Microkernel submodule

[[pm][ikc] Feature: Preemptive threads](https://github.com/nanvix/microkernel/pull/298)